### PR TITLE
perf: 검색 성능 개선 - API 병렬화, 다중 페이지 집계, 요청 캐싱

### DIFF
--- a/web/src/lib/work-agent/index.ts
+++ b/web/src/lib/work-agent/index.ts
@@ -33,6 +33,8 @@ export {
   type ToolCallHistory,
   type UserIntent,
 } from "./prompts"
+// Request Cache
+export { RequestCache } from "./request-cache"
 // Source Tracker (출처 검증)
 export {
   buildSearchContextFromSteps,
@@ -43,6 +45,7 @@ export {
 export {
   answer,
   createAnswerTool,
+  createCachedWorkAgentTools,
   getNotionPage,
   searchClickUpDocs as searchClickUpDocsTool,
   searchClickUpTasks as searchClickUpTasksTool,

--- a/web/src/lib/work-agent/request-cache.ts
+++ b/web/src/lib/work-agent/request-cache.ts
@@ -1,0 +1,57 @@
+/**
+ * Request-level Cache
+ * 에이전트 루프 내에서 동일한 API 호출 결과를 재사용하여 성능 최적화
+ * 요청(채팅 1회) 단위로 생성/폐기되므로 메모리 누수 없음
+ */
+
+export class RequestCache {
+  private cache = new Map<string, unknown>()
+
+  /**
+   * 캐시 키 생성
+   */
+  private createKey(toolName: string, params: Record<string, unknown>): string {
+    return `${toolName}:${JSON.stringify(params)}`
+  }
+
+  /**
+   * 캐시에서 결과 조회
+   */
+  get<T>(toolName: string, params: Record<string, unknown>): T | undefined {
+    const key = this.createKey(toolName, params)
+    return this.cache.get(key) as T | undefined
+  }
+
+  /**
+   * 결과를 캐시에 저장
+   */
+  set<T>(toolName: string, params: Record<string, unknown>, result: T): void {
+    const key = this.createKey(toolName, params)
+    this.cache.set(key, result)
+  }
+
+  /**
+   * 캐시된 결과가 있으면 반환, 없으면 fn 실행 후 캐시
+   */
+  async getOrFetch<T>(
+    toolName: string,
+    params: Record<string, unknown>,
+    fn: () => Promise<T>
+  ): Promise<T> {
+    const cached = this.get<T>(toolName, params)
+    if (cached !== undefined) {
+      return cached
+    }
+
+    const result = await fn()
+    this.set(toolName, params, result)
+    return result
+  }
+
+  /**
+   * 캐시 크기 조회 (디버깅용)
+   */
+  get size(): number {
+    return this.cache.size
+  }
+}

--- a/web/tests/lib/work-agent/request-cache.test.ts
+++ b/web/tests/lib/work-agent/request-cache.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it, vi } from "vitest"
+import { RequestCache } from "@/lib/work-agent/request-cache"
+
+describe("RequestCache", () => {
+  describe("get / set", () => {
+    it("캐시 미스 시 undefined 반환", () => {
+      const cache = new RequestCache()
+      expect(cache.get("searchNotion", { query: "test" })).toBeUndefined()
+    })
+
+    it("캐시 히트 시 저장된 값 반환", () => {
+      const cache = new RequestCache()
+      const result = { success: true, data: { pages: [] } }
+      cache.set("searchNotion", { query: "test" }, result)
+      expect(cache.get("searchNotion", { query: "test" })).toEqual(result)
+    })
+
+    it("다른 파라미터는 별도 캐시 항목", () => {
+      const cache = new RequestCache()
+      const result1 = { data: "result1" }
+      const result2 = { data: "result2" }
+      cache.set("searchNotion", { query: "react" }, result1)
+      cache.set("searchNotion", { query: "typescript" }, result2)
+
+      expect(cache.get("searchNotion", { query: "react" })).toEqual(result1)
+      expect(cache.get("searchNotion", { query: "typescript" })).toEqual(result2)
+    })
+
+    it("다른 도구 이름은 별도 캐시 항목", () => {
+      const cache = new RequestCache()
+      const result1 = { data: "notion" }
+      const result2 = { data: "clickup" }
+      cache.set("searchNotion", { query: "test" }, result1)
+      cache.set("searchClickUpTasks", { query: "test" }, result2)
+
+      expect(cache.get("searchNotion", { query: "test" })).toEqual(result1)
+      expect(cache.get("searchClickUpTasks", { query: "test" })).toEqual(result2)
+    })
+  })
+
+  describe("getOrFetch", () => {
+    it("캐시 미스 시 fn 실행하고 결과를 캐시", async () => {
+      const cache = new RequestCache()
+      const fn = vi.fn().mockResolvedValue({ success: true, data: { pages: [] } })
+
+      const result = await cache.getOrFetch("searchNotion", { query: "test" }, fn)
+
+      expect(fn).toHaveBeenCalledTimes(1)
+      expect(result).toEqual({ success: true, data: { pages: [] } })
+
+      // 두 번째 호출 - fn이 다시 호출되지 않아야 함
+      const result2 = await cache.getOrFetch("searchNotion", { query: "test" }, fn)
+      expect(fn).toHaveBeenCalledTimes(1)
+      expect(result2).toEqual(result)
+    })
+
+    it("다른 파라미터로 호출 시 fn 재실행", async () => {
+      const cache = new RequestCache()
+      const fn = vi
+        .fn()
+        .mockResolvedValueOnce({ data: "result1" })
+        .mockResolvedValueOnce({ data: "result2" })
+
+      await cache.getOrFetch("searchNotion", { query: "react" }, fn)
+      await cache.getOrFetch("searchNotion", { query: "typescript" }, fn)
+
+      expect(fn).toHaveBeenCalledTimes(2)
+    })
+  })
+
+  describe("size", () => {
+    it("캐시 크기 추적", () => {
+      const cache = new RequestCache()
+      expect(cache.size).toBe(0)
+
+      cache.set("tool1", { key: "a" }, "value1")
+      expect(cache.size).toBe(1)
+
+      cache.set("tool2", { key: "b" }, "value2")
+      expect(cache.size).toBe(2)
+    })
+  })
+})


### PR DESCRIPTION
- Notion: 페이지 메타데이터와 블록 콘텐츠를 Promise.all로 병렬 fetch
- Notion: 자식 블록들을 순차 대신 Promise.all로 병렬 fetch
- ClickUp Tasks: 단일 페이지 대신 최대 5페이지까지 집계하여 검색 누락 방지
- ClickUp Docs: 단일 페이지 대신 최대 5페이지까지 집계하여 검색 누락 방지
- RequestCache: 에이전트 루프 내 동일 파라미터 반복 호출 시 캐시 반환
- chat.ts: createCachedWorkAgentTools로 캐시 적용된 도구 사용

https://claude.ai/code/session_01KsCyLLQbQDeWqb4kwvFa5L

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Task and document searches now automatically aggregate results across multiple pages, delivering more comprehensive results without requiring manual pagination.

* **Performance Improvements**
  * Implemented request-scoped caching for search operations to reduce redundant API calls.
  * Optimized Notion block retrieval through parallel fetching for improved responsiveness.

* **API Changes**
  * Removed `page` parameter from search options; pagination is now handled automatically.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->