### PR TITLE
fix: API 어댑터 레이어 링크 경로 수정

### DIFF
--- a/web/src/content/projects/exem-new-generation.md
+++ b/web/src/content/projects/exem-new-generation.md
@@ -9,7 +9,7 @@ priority: 3
 
 #### API 레이어 아키텍처 재설계 및 타입 안정성 강화
 
-**[API 어댑터 레이어의 실용적 추상화](https://publish.obsidian.md/gihwan-dev/Exem/%ED%98%84+API+%EB%AC%B8%EC%A0%9C%EC%A0%90)**
+**[API 어댑터 레이어의 실용적 추상화](https://publish.obsidian.md/gihwan-dev/Exem/03-Knowledge/API/%ED%98%84+API+%EB%AC%B8%EC%A0%9C%EC%A0%90)**
 
 **Problem**
 


### PR DESCRIPTION
Obsidian 게시 링크에 누락된 03-Knowledge/API/ 경로를 추가

https://claude.ai/code/session_013YuMXvHhqML8FXzjE85nfV

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated internal documentation links for improved navigation accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->