### PR TITLE
perf: Astro hydration 전략 변경 (client:load → client:idle)

### DIFF
--- a/web/src/layouts/Layout.astro
+++ b/web/src/layouts/Layout.astro
@@ -78,9 +78,9 @@ const gaId = import.meta.env.PUBLIC_GA_MEASUREMENT_ID
   <body
     class="bg-resume-bg text-resume-text-main min-h-screen font-sans antialiased selection:bg-resume-primary selection:text-white"
   >
-    <Navigation client:load />
+    <Navigation client:idle />
     <slot />
-    <ChatWidget client:load />
+    <ChatWidget client:idle />
   </body>
 </html>
 


### PR DESCRIPTION
## Summary
- `Layout.astro`에서 `Navigation`과 `ChatWidget`의 hydration 전략을 `client:load` → `client:idle`로 변경
- 페이지 로드 시 메인 스레드 차단(300-800ms)을 제거하여 TTI 300-600ms 개선 예상
- 브라우저가 idle 상태일 때 hydration이 실행되므로 사용자 체감 성능 향상

## Test plan
- [ ] `pnpm dev`로 로컬 서버에서 Navigation/ChatWidget 정상 동작 확인
- [ ] DevTools Performance 탭에서 hydration이 idle 시점으로 지연되었는지 확인
- [ ] `pnpm build && pnpm preview`로 프로덕션 빌드 검증
- [ ] E2E 테스트 통과 확인 (`npx playwright test e2e/chat-fab.spec.ts`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Optimized component initialization to defer execution until the browser is idle, improving initial page load performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->