### PR TITLE
fix: CSS 와일드카드 트랜지션 제거

### DIFF
--- a/web/src/components/navigation/desktop-nav.tsx
+++ b/web/src/components/navigation/desktop-nav.tsx
@@ -6,9 +6,9 @@ import { ThemeToggle } from "./theme-toggle"
 export function DesktopNav() {
   return (
     <div className="fixed left-1/2 top-1/2 -translate-y-1/2 translate-x-[calc(448px+2rem)] z-100">
-      <div className="bg-resume-card-bg border border-resume-border rounded-xl shadow-resume-shadow p-4 flex flex-col gap-4">
+      <div className="bg-resume-card-bg border border-resume-border rounded-xl shadow-resume-shadow p-4 flex flex-col gap-4 transition-colors duration-100">
         <ThemeToggle />
-        <div className="border-t border-resume-border pt-4">
+        <div className="border-t border-resume-border pt-4 transition-colors duration-100">
           <SectionNav />
         </div>
       </div>

--- a/web/src/components/navigation/mobile-nav.tsx
+++ b/web/src/components/navigation/mobile-nav.tsx
@@ -27,7 +27,7 @@ export function MobileNav() {
             <span className="sr-only">Open menu</span>
           </Button>
         </SheetTrigger>
-        <SheetContent side="right" className="w-64 bg-resume-card-bg">
+        <SheetContent side="right" className="w-64 bg-resume-card-bg transition-colors duration-100">
           <SheetHeader>
             <SheetTitle className="text-resume-text-heading">Menu</SheetTitle>
           </SheetHeader>
@@ -36,7 +36,7 @@ export function MobileNav() {
               <span className="text-sm text-resume-text-muted">Theme</span>
               <ThemeToggle />
             </div>
-            <div className="border-t border-resume-border pt-4">
+            <div className="border-t border-resume-border pt-4 transition-colors duration-100">
               <span className="text-xs font-medium uppercase text-resume-text-muted tracking-wider mb-2 block">
                 Sections
               </span>

--- a/web/src/components/ui/separator.tsx
+++ b/web/src/components/ui/separator.tsx
@@ -17,7 +17,7 @@ function Separator({
       decorative={decorative}
       orientation={orientation}
       className={cn(
-        "bg-border shrink-0 data-[orientation=horizontal]:h-px data-[orientation=horizontal]:w-full data-[orientation=vertical]:h-full data-[orientation=vertical]:w-px",
+        "bg-border shrink-0 transition-colors duration-100 data-[orientation=horizontal]:h-px data-[orientation=horizontal]:w-full data-[orientation=vertical]:h-full data-[orientation=vertical]:w-px",
         className
       )}
       {...props}

--- a/web/src/layouts/Layout.astro
+++ b/web/src/layouts/Layout.astro
@@ -76,7 +76,7 @@ const gaId = import.meta.env.PUBLIC_GA_MEASUREMENT_ID
     </script>
   </head>
   <body
-    class="bg-resume-bg text-resume-text-main min-h-screen font-sans antialiased selection:bg-resume-primary selection:text-white"
+    class="bg-resume-bg text-resume-text-main min-h-screen font-sans antialiased selection:bg-resume-primary selection:text-white transition-colors duration-100"
   >
     <Navigation client:load />
     <slot />

--- a/web/src/styles/global.css
+++ b/web/src/styles/global.css
@@ -176,9 +176,6 @@
 @layer base {
   * {
     @apply border-border outline-ring/50;
-    transition-property: color, background-color, border-color, text-decoration-color, fill, stroke;
-    transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
-    transition-duration: 100ms;
   }
 
   body {


### PR DESCRIPTION
## Summary
- `global.css`의 `* { transition-property: ... }` 규칙 제거 — 200개+ DOM 요소에 불필요한 100ms 트랜지션을 유발하던 원인
- 테마 전환 시 실제로 색상이 변하는 핵심 요소에만 `transition-colors duration-100` 적용: `<body>`, 데스크톱/모바일 네비게이션, Separator 컴포넌트
- 기존에 `transition-colors`/`transition-all`을 가진 컴포넌트(button, badge, switch, section-nav, 카드 등)는 변경 없음

## Test plan
- [ ] `pnpm dev`로 테마 토글(다크/라이트) 시 body, 네비게이션, separator가 부드럽게 전환되는지 확인
- [ ] 기존 카드/링크/버튼 호버 효과가 정상 동작하는지 확인
- [ ] 테마 토글 시 어색하게 깜빡이는 요소가 없는지 확인
- [ ] `pnpm build` 성공 확인

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

**Style**
- Optimized color transition animations across navigation menus and separator components for improved visual consistency and smoother interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->