### PR TITLE
feat: Reasoning 영역에 마크다운 렌더링 적용

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -53,6 +53,7 @@
     "next-themes": "^0.4.6",
     "react": "^19.2.3",
     "react-dom": "^19.2.3",
+    "react-markdown": "^10.1.0",
     "remark-gfm": "^4.0.1",
     "tailwind-merge": "^3.4.0",
     "tailwindcss": "^4.1.18",

--- a/web/pnpm-lock.yaml
+++ b/web/pnpm-lock.yaml
@@ -116,6 +116,9 @@ importers:
       react-dom:
         specifier: ^19.2.3
         version: 19.2.3(react@19.2.3)
+      react-markdown:
+        specifier: ^10.1.0
+        version: 10.1.0(@types/react@19.2.9)(react@19.2.3)
       remark-gfm:
         specifier: ^4.0.1
         version: 4.0.1

--- a/web/src/components/assistant-ui/reasoning.tsx
+++ b/web/src/components/assistant-ui/reasoning.tsx
@@ -1,15 +1,48 @@
 "use client"
 
 import type { ReasoningGroupComponent, ReasoningMessagePartComponent } from "@assistant-ui/react"
-import type { PropsWithChildren } from "react"
+import { memo, type PropsWithChildren } from "react"
+import Markdown from "react-markdown"
+import remarkGfm from "remark-gfm"
 import { useThinkingProcess } from "@/components/assistant-ui/thinking-process"
 
-export const Reasoning: ReasoningMessagePartComponent = ({ text }) => {
+const reasoningComponents = {
+  strong: ({ ...props }: React.ComponentProps<"strong">) => (
+    <strong className="font-semibold" {...props} />
+  ),
+  p: ({ ...props }: React.ComponentProps<"p">) => (
+    <p className="my-1 leading-relaxed first:mt-0 last:mb-0" {...props} />
+  ),
+  ul: ({ ...props }: React.ComponentProps<"ul">) => (
+    <ul className="my-1 ml-3 list-disc [&>li]:mt-0.5" {...props} />
+  ),
+  ol: ({ ...props }: React.ComponentProps<"ol">) => (
+    <ol className="my-1 ml-3 list-decimal [&>li]:mt-0.5" {...props} />
+  ),
+  li: ({ ...props }: React.ComponentProps<"li">) => <li className="leading-relaxed" {...props} />,
+  a: ({ ...props }: React.ComponentProps<"a">) => (
+    <a className="text-primary underline underline-offset-2 hover:text-primary/80" {...props} />
+  ),
+  code: ({ ...props }: React.ComponentProps<"code">) => (
+    <code
+      className="rounded-md border border-border/50 bg-muted/50 px-1 py-0.5 font-mono text-[0.85em]"
+      {...props}
+    />
+  ),
+}
+
+const ReasoningImpl: ReasoningMessagePartComponent = ({ text }) => {
   if (!text) return null
   return (
-    <p className="whitespace-pre-wrap text-xs text-muted-foreground/70 leading-relaxed">{text}</p>
+    <div className="text-xs text-muted-foreground/70">
+      <Markdown remarkPlugins={[remarkGfm]} components={reasoningComponents}>
+        {text}
+      </Markdown>
+    </div>
   )
 }
+
+export const Reasoning = memo(ReasoningImpl)
 
 export const ReasoningGroupWrapper: ReasoningGroupComponent = ({ children }: PropsWithChildren) => {
   const { isOpen } = useThinkingProcess()


### PR DESCRIPTION
## Summary
- 사고 과정(reasoning) 영역에서 `**bold**`, 리스트 등 마크다운이 원시 텍스트로 노출되던 문제 수정
- `react-markdown` + `remarkGfm`을 사용하여 마크다운 렌더링 적용
- reasoning 컨텍스트에 맞게 간소화된 컴포넌트 오버라이드 (strong, p, ul, ol, li, a, code)

## Test plan
- [ ] `pnpm dev`로 개발 서버 실행 후 챗봇 사고 과정 아코디언에서 bold, 리스트 등 마크다운 렌더링 확인
- [ ] 기존 스타일 톤(text-xs, text-muted-foreground/70) 유지 확인
- [ ] `pnpm lint` 통과 확인