### PR TITLE
feat: 벨로그 RSS 블로그 섹션 및 PDF 출력 반영

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -49,6 +49,7 @@
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "embla-carousel-react": "^8.6.0",
+    "fast-xml-parser": "^4.5.3",
     "firebase": "^12.8.0",
     "firebase-admin": "^13.6.0",
     "lucide-react": "^0.562.0",
@@ -64,8 +65,8 @@
     "zustand": "^5.0.10"
   },
   "devDependencies": {
-    "@axe-core/playwright": "^4.10.2",
     "@astrojs/check": "^0.9.6",
+    "@axe-core/playwright": "^4.10.2",
     "@biomejs/biome": "2.3.11",
     "@playwright/test": "^1.58.2",
     "@types/node": "^25.0.10",

--- a/web/pnpm-lock.yaml
+++ b/web/pnpm-lock.yaml
@@ -98,6 +98,9 @@ importers:
       embla-carousel-react:
         specifier: ^8.6.0
         version: 8.6.0(react@19.2.3)
+      fast-xml-parser:
+        specifier: ^4.5.3
+        version: 4.5.3
       firebase:
         specifier: ^12.8.0
         version: 12.8.0
@@ -9883,7 +9886,6 @@ snapshots:
   fast-xml-parser@4.5.3:
     dependencies:
       strnum: 1.1.2
-    optional: true
 
   faye-websocket@0.11.4:
     dependencies:
@@ -12042,8 +12044,7 @@ snapshots:
     dependencies:
       ansi-regex: 6.2.2
 
-  strnum@1.1.2:
-    optional: true
+  strnum@1.1.2: {}
 
   stubborn-fs@2.0.0:
     dependencies:

--- a/web/src/components/navigation/section-nav.tsx
+++ b/web/src/components/navigation/section-nav.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { Award, Briefcase, FolderKanban, Trophy, User } from "lucide-react"
+import { Award, Briefcase, FileText, FolderKanban, Trophy, User } from "lucide-react"
 import type { MouseEvent } from "react"
 import { type SectionId, useActiveSection } from "@/hooks/use-active-section"
 import { cn } from "@/lib/utils"
@@ -15,6 +15,7 @@ const sections: { id: SectionId; label: string; icon: typeof User }[] = [
   { id: "profile", label: "Profile", icon: User },
   { id: "experience", label: "Experience", icon: Briefcase },
   { id: "projects", label: "Projects", icon: FolderKanban },
+  { id: "blog", label: "Blog", icon: FileText },
   { id: "certificates", label: "Certificates", icon: Award },
   { id: "awards", label: "Awards", icon: Trophy },
 ]

--- a/web/src/components/pdf/resume-document.tsx
+++ b/web/src/components/pdf/resume-document.tsx
@@ -119,6 +119,26 @@ function ProjectSection({ projects }: { projects: SerializedResumeData["projects
   )
 }
 
+function BlogSection({ blogPosts }: { blogPosts: SerializedResumeData["blogPosts"] }) {
+  if (blogPosts.length === 0) return null
+  return (
+    <View>
+      <Text style={styles.sectionTitle}>Blog</Text>
+      {blogPosts.map((post) => (
+        <View key={post.url} style={styles.itemSeparator} wrap={false}>
+          <View style={styles.itemHeader}>
+            <Text style={styles.itemTitle}>{post.title}</Text>
+            <Text style={styles.itemDate}>{formatDate(post.publishedAt)}</Text>
+          </View>
+          <Link src={post.url} style={styles.link}>
+            <Text style={styles.blogLinkText}>Read post</Text>
+          </Link>
+        </View>
+      ))}
+    </View>
+  )
+}
+
 function EducationSection({ education }: { education: SerializedResumeData["education"] }) {
   if (education.length === 0) return null
   return (
@@ -195,6 +215,7 @@ export function ResumeDocument({ data }: { data: SerializedResumeData }) {
         <SkillsSection skills={data.skills} />
         <ExperienceSection work={data.work} />
         <ProjectSection projects={data.projects} />
+        <BlogSection blogPosts={data.blogPosts} />
         <EducationSection education={data.education} />
         <CertificateSection certificates={data.certificates} />
         <AwardSection awards={data.awards} />

--- a/web/src/hooks/use-active-section.ts
+++ b/web/src/hooks/use-active-section.ts
@@ -2,9 +2,16 @@
 
 import { useEffect, useRef, useState } from "react"
 
-export type SectionId = "profile" | "experience" | "projects" | "certificates" | "awards"
+export type SectionId = "profile" | "experience" | "projects" | "blog" | "certificates" | "awards"
 
-const SECTION_IDS: SectionId[] = ["profile", "experience", "projects", "certificates", "awards"]
+const SECTION_IDS: SectionId[] = [
+  "profile",
+  "experience",
+  "projects",
+  "blog",
+  "certificates",
+  "awards",
+]
 
 export function useActiveSection(): SectionId | null {
   const [activeSection, setActiveSection] = useState<SectionId | null>(null)

--- a/web/src/lib/blog/velog.ts
+++ b/web/src/lib/blog/velog.ts
@@ -1,0 +1,163 @@
+import { XMLParser } from "fast-xml-parser"
+
+const VELOG_USERNAME = "koreanthuglife"
+const VELOG_POSTS_URL = `https://velog.io/@${VELOG_USERNAME}/posts`
+const VELOG_RSS_URL = `https://v2.velog.io/rss/${VELOG_USERNAME}`
+const CACHE_TTL_MS = 24 * 60 * 60 * 1000
+const DEFAULT_LIMIT = 5
+
+export interface VelogPost {
+  title: string
+  url: string
+  publishedAt: string
+  summary?: string
+}
+
+interface CachedVelogPosts {
+  fetchedAt: number
+  posts: VelogPost[]
+}
+
+interface VelogRssItem {
+  title?: unknown
+  link?: unknown
+  pubDate?: unknown
+  description?: unknown
+}
+
+interface VelogRssDocument {
+  rss?: {
+    channel?: {
+      item?: VelogRssItem | VelogRssItem[]
+    }
+  }
+}
+
+let cache: CachedVelogPosts | null = null
+let inflightRequest: Promise<VelogPost[]> | null = null
+
+function toArray<T>(value: T | T[] | undefined): T[] {
+  if (Array.isArray(value)) return value
+  if (value === undefined) return []
+  return [value]
+}
+
+function readRssText(value: unknown): string {
+  if (typeof value === "string") return value.trim()
+  if (!value || typeof value !== "object") return ""
+
+  const cdataValue = (value as Record<string, unknown>)["#cdata"]
+  if (typeof cdataValue === "string") {
+    return cdataValue.trim()
+  }
+
+  return ""
+}
+
+function stripHtml(value: string): string {
+  return value
+    .replace(/<[^>]*>/g, " ")
+    .replace(/&nbsp;/g, " ")
+    .replace(/\s+/g, " ")
+    .trim()
+}
+
+function summarize(description: string): string | undefined {
+  const cleaned = stripHtml(description)
+  if (!cleaned) return undefined
+  if (cleaned.length <= 180) return cleaned
+  return `${cleaned.slice(0, 177)}...`
+}
+
+function parseRss(xml: string): VelogPost[] {
+  const parser = new XMLParser({
+    trimValues: true,
+    ignoreAttributes: true,
+    parseTagValue: false,
+    cdataPropName: "#cdata",
+  })
+
+  const parsed = parser.parse(xml) as VelogRssDocument
+  const items = toArray(parsed.rss?.channel?.item)
+  const posts: VelogPost[] = []
+
+  for (const item of items) {
+    const title = readRssText(item.title)
+    const url = readRssText(item.link)
+    const pubDateRaw = readRssText(item.pubDate)
+    const summaryRaw = readRssText(item.description)
+    const publishedAtUnix = Date.parse(pubDateRaw)
+
+    if (!title || !url || Number.isNaN(publishedAtUnix)) {
+      continue
+    }
+
+    posts.push({
+      title,
+      url,
+      publishedAt: new Date(publishedAtUnix).toISOString(),
+      summary: summarize(summaryRaw),
+    })
+  }
+
+  posts.sort((a, b) => Date.parse(b.publishedAt) - Date.parse(a.publishedAt))
+  return posts
+}
+
+async function fetchVelogPosts(): Promise<VelogPost[]> {
+  const response = await fetch(VELOG_RSS_URL, {
+    headers: {
+      Accept: "application/rss+xml, application/xml, text/xml",
+    },
+    cache: "no-store",
+  })
+
+  if (!response.ok) {
+    throw new Error(`Failed to fetch Velog RSS: ${response.status}`)
+  }
+
+  const xml = await response.text()
+  return parseRss(xml)
+}
+
+function normalizeLimit(limit: number | undefined): number {
+  if (limit === undefined) return DEFAULT_LIMIT
+  if (!Number.isFinite(limit)) return DEFAULT_LIMIT
+  if (limit <= 0) return 0
+  return Math.floor(limit)
+}
+
+export async function getVelogPosts(options: { limit?: number } = {}): Promise<VelogPost[]> {
+  const limit = normalizeLimit(options.limit)
+  const now = Date.now()
+
+  if (cache && now - cache.fetchedAt < CACHE_TTL_MS) {
+    return cache.posts.slice(0, limit)
+  }
+
+  if (!inflightRequest) {
+    inflightRequest = fetchVelogPosts()
+      .then((posts) => {
+        cache = {
+          fetchedAt: Date.now(),
+          posts,
+        }
+        return posts
+      })
+      .catch((error) => {
+        console.error("[velog] RSS fetch failed.", error)
+        if (cache) {
+          return cache.posts
+        }
+        return []
+      })
+      .finally(() => {
+        inflightRequest = null
+      })
+  }
+
+  const posts = await inflightRequest
+  return posts.slice(0, limit)
+}
+
+export const VELOG_POSTS_PAGE_URL = VELOG_POSTS_URL

--- a/web/src/lib/pdf/serialize-resume.ts
+++ b/web/src/lib/pdf/serialize-resume.ts
@@ -1,16 +1,19 @@
 import { getCollection } from "astro:content"
+import { getVelogPosts } from "@/lib/blog/velog"
 import type { SerializedResumeData } from "./types"
 
 export async function serializeResumeData(): Promise<SerializedResumeData> {
-  const [basics, work, projects, education, certificates, awards, skills] = await Promise.all([
-    getCollection("basics"),
-    getCollection("work"),
-    getCollection("projects"),
-    getCollection("education"),
-    getCollection("certificates"),
-    getCollection("awards"),
-    getCollection("skills"),
-  ])
+  const [basics, work, projects, education, certificates, awards, skills, blogPosts] =
+    await Promise.all([
+      getCollection("basics"),
+      getCollection("work"),
+      getCollection("projects"),
+      getCollection("education"),
+      getCollection("certificates"),
+      getCollection("awards"),
+      getCollection("skills"),
+      getVelogPosts({ limit: 5 }),
+    ])
 
   const profile = basics[0]?.data
 
@@ -51,6 +54,7 @@ export async function serializeResumeData(): Promise<SerializedResumeData> {
       dateEnd: p.data.dateEnd?.toISOString(),
       body: p.body?.trim() || undefined,
     })),
+    blogPosts,
     education: education.map((e) => ({
       institution: e.data.institution,
       area: e.data.area,

--- a/web/src/lib/pdf/styles.ts
+++ b/web/src/lib/pdf/styles.ts
@@ -92,6 +92,10 @@ export const styles = StyleSheet.create({
     lineHeight: 1.5,
     marginBottom: 6,
   },
+  blogLinkText: {
+    fontSize: 8,
+    marginBottom: 2,
+  },
   itemSeparator: {
     marginBottom: 12,
   },

--- a/web/src/lib/pdf/types.ts
+++ b/web/src/lib/pdf/types.ts
@@ -58,10 +58,18 @@ export interface SerializedSkillCategory {
   items: string[]
 }
 
+export interface SerializedBlogPost {
+  title: string
+  url: string
+  publishedAt: string
+  summary?: string
+}
+
 export interface SerializedResumeData {
   profile: SerializedProfile
   work: SerializedWork[]
   projects: SerializedProject[]
+  blogPosts: SerializedBlogPost[]
   education: SerializedEducation[]
   certificates: SerializedCertificate[]
   awards: SerializedAward[]

--- a/web/src/pages/_sections/blog-section.astro
+++ b/web/src/pages/_sections/blog-section.astro
@@ -1,0 +1,69 @@
+---
+import { VELOG_POSTS_PAGE_URL } from "@/lib/blog/velog"
+
+interface BlogPostItem {
+  title: string
+  url: string
+  publishedAt: string
+  summary?: string
+}
+
+const { posts = [] } = Astro.props as { posts?: BlogPostItem[] }
+
+function formatDate(iso: string): string {
+  const date = new Date(iso)
+  return date.toLocaleDateString("en-US", {
+    year: "numeric",
+    month: "short",
+    day: "numeric",
+  })
+}
+---
+
+<section id="blog" class="mb-12">
+  <h2 class="text-2xl font-bold text-resume-text-main mb-8 tracking-tight">Blog</h2>
+
+  {
+    posts.length > 0 ? (
+      <div class="space-y-4">
+        {posts.map((post) => (
+          <article class="group bg-resume-card-bg rounded-sm border border-resume-border p-5 transition-all duration-300 hover:border-resume-primary/50 hover:bg-resume-highlight/30">
+            <div class="flex flex-col gap-2 sm:flex-row sm:items-start sm:justify-between">
+              <a
+                href={post.url}
+                target="_blank"
+                rel="noopener noreferrer"
+                class="text-base font-semibold text-resume-text-heading group-hover:text-resume-primary transition-colors underline-offset-4 hover:underline focus-visible:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-resume-bg rounded-sm"
+                data-ga-event="blog_post_click"
+                data-ga-post={post.title}
+                data-ga-source="velog"
+              >
+                {post.title}
+              </a>
+              <span class="text-sm text-resume-text-muted font-mono whitespace-nowrap">
+                {formatDate(post.publishedAt)}
+              </span>
+            </div>
+
+            {post.summary && <p class="mt-3 text-sm text-resume-text-muted leading-relaxed">{post.summary}</p>}
+          </article>
+        ))}
+      </div>
+    ) : (
+      <p class="text-resume-text-muted">최근 블로그 글을 불러오지 못했습니다.</p>
+    )
+  }
+
+  <div class="mt-6">
+    <a
+      href={VELOG_POSTS_PAGE_URL}
+      target="_blank"
+      rel="noopener noreferrer"
+      class="inline-flex items-center text-sm font-medium text-resume-primary hover:text-resume-secondary focus-visible:text-resume-secondary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-resume-bg rounded-sm transition-colors"
+      data-ga-event="blog_all_posts_click"
+      data-ga-source="velog"
+    >
+      View all posts
+    </a>
+  </div>
+</section>

--- a/web/src/pages/index.astro
+++ b/web/src/pages/index.astro
@@ -2,9 +2,11 @@
 import { getCollection, render } from "astro:content"
 import { PdfDownloadButton } from "@/components/pdf/pdf-download-button"
 import { Separator } from "@/components/ui/separator"
+import { getVelogPosts } from "@/lib/blog/velog"
 import { serializeResumeData } from "@/lib/pdf/serialize-resume"
 import Layout from "../layouts/Layout.astro"
 import AwardSection from "./_sections/award-section.astro"
+import BlogSection from "./_sections/blog-section.astro"
 import CertificateSection from "./_sections/certificate-section.astro"
 import ExperienceSection from "./_sections/experience-section.astro"
 import HeroSection from "./_sections/hero-section.astro"
@@ -19,6 +21,7 @@ const skillsData = skills[0]?.data
 
 const work = await getCollection("work")
 const projects = await getCollection("projects")
+const blogPosts = await getVelogPosts({ limit: 5 })
 
 const certificates = await getCollection("certificates")
 const awards = await getCollection("awards")
@@ -77,6 +80,10 @@ const projectsWithContent = await Promise.all(
 
     <Separator className="my-12" />
 
+    <BlogSection posts={blogPosts} />
+
+    <Separator className="my-12" />
+
     <CertificateSection certificates={certificates} />
 
     <Separator className="my-12" />
@@ -109,7 +116,7 @@ const projectsWithContent = await Promise.all(
 
     // 섹션 뷰 추적: Intersection Observer
     const sections = document.querySelectorAll<HTMLElement>(
-      "#profile, #skills, #experience, #projects, #certificates, #awards"
+      "#profile, #skills, #experience, #projects, #blog, #certificates, #awards"
     )
     const viewed = new Set<string>()
 

--- a/web/tests/lib/blog/velog.test.ts
+++ b/web/tests/lib/blog/velog.test.ts
@@ -1,0 +1,108 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+
+const DAY_MS = 24 * 60 * 60 * 1000
+
+const RSS_SAMPLE = `<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0">
+  <channel>
+    <item>
+      <title><![CDATA[첫 번째 글]]></title>
+      <link>https://velog.io/@koreanthuglife/first-post</link>
+      <pubDate>Sun, 11 Jan 2026 08:17:53 GMT</pubDate>
+      <description><![CDATA[<p>첫 번째 <strong>요약</strong> 문장입니다.</p>]]></description>
+    </item>
+    <item>
+      <title><![CDATA[두 번째 글]]></title>
+      <link>https://velog.io/@koreanthuglife/second-post</link>
+      <pubDate>Sat, 10 Jan 2026 08:17:53 GMT</pubDate>
+      <description><![CDATA[<p>두 번째 글 설명입니다.</p>]]></description>
+    </item>
+  </channel>
+</rss>`
+
+async function loadVelogModule() {
+  vi.resetModules()
+  return import("../../../src/lib/blog/velog")
+}
+
+describe("velog blog rss", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+    vi.unstubAllGlobals()
+  })
+
+  it("RSS를 파싱하고 limit를 적용한다", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue(new Response(RSS_SAMPLE, { status: 200, statusText: "OK" }))
+    vi.stubGlobal("fetch", fetchMock)
+
+    const { getVelogPosts } = await loadVelogModule()
+    const posts = await getVelogPosts({ limit: 1 })
+
+    expect(posts).toHaveLength(1)
+    expect(posts[0]).toMatchObject({
+      title: "첫 번째 글",
+      url: "https://velog.io/@koreanthuglife/first-post",
+      publishedAt: "2026-01-11T08:17:53.000Z",
+    })
+    expect(posts[0].summary).toBe("첫 번째 요약 문장입니다.")
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+  })
+
+  it("캐시가 유효하면 재호출 시 fetch를 생략한다", async () => {
+    let currentTime = 0
+    vi.spyOn(Date, "now").mockImplementation(() => currentTime)
+
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue(new Response(RSS_SAMPLE, { status: 200, statusText: "OK" }))
+    vi.stubGlobal("fetch", fetchMock)
+
+    const { getVelogPosts } = await loadVelogModule()
+
+    const first = await getVelogPosts({ limit: 5 })
+    currentTime = 60 * 1000
+    const second = await getVelogPosts({ limit: 5 })
+
+    expect(second).toEqual(first)
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+  })
+
+  it("캐시가 만료된 뒤 fetch 실패 시 stale 캐시를 반환한다", async () => {
+    let currentTime = 0
+    vi.spyOn(Date, "now").mockImplementation(() => currentTime)
+    vi.spyOn(console, "error").mockImplementation(() => {})
+
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(new Response(RSS_SAMPLE, { status: 200, statusText: "OK" }))
+      .mockRejectedValueOnce(new Error("network error"))
+    vi.stubGlobal("fetch", fetchMock)
+
+    const { getVelogPosts } = await loadVelogModule()
+
+    const cached = await getVelogPosts({ limit: 5 })
+    currentTime = DAY_MS + 1
+    const stale = await getVelogPosts({ limit: 5 })
+
+    expect(stale).toEqual(cached)
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+  })
+
+  it("초기 fetch 실패 시 빈 배열을 반환한다", async () => {
+    vi.spyOn(console, "error").mockImplementation(() => {})
+    const fetchMock = vi.fn().mockRejectedValue(new Error("network error"))
+    vi.stubGlobal("fetch", fetchMock)
+
+    const { getVelogPosts } = await loadVelogModule()
+    const posts = await getVelogPosts({ limit: 5 })
+
+    expect(posts).toEqual([])
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+  })
+})

--- a/web/tests/lib/pdf/serialize-resume.test.ts
+++ b/web/tests/lib/pdf/serialize-resume.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, it, vi } from "vitest"
+
+const { mockGetCollection, mockGetVelogPosts } = vi.hoisted(() => ({
+  mockGetCollection: vi.fn(),
+  mockGetVelogPosts: vi.fn(),
+}))
+
+vi.mock("@/lib/blog/velog", () => ({
+  getVelogPosts: mockGetVelogPosts,
+}))
+
+vi.mock("astro:content", () => ({
+  getCollection: mockGetCollection,
+}))
+
+import { serializeResumeData } from "../../../src/lib/pdf/serialize-resume"
+
+describe("serializeResumeData", () => {
+  it("blogPosts를 포함해 직렬화한다", async () => {
+    mockGetCollection.mockReset()
+    mockGetVelogPosts.mockReset()
+    mockGetCollection.mockImplementation(async (collectionName) => {
+      switch (collectionName) {
+        case "basics":
+          return [
+            {
+              data: {
+                name: "최기환",
+                label: "Frontend Developer",
+                email: "test@example.com",
+                url: "https://resume-with-ai.gihwan-dev.com",
+                summary: "summary",
+                profiles: [],
+              },
+            },
+          ] as never
+        case "work":
+          return [
+            {
+              data: {
+                company: "Exem",
+                role: "Frontend Engineer",
+                dateStart: new Date("2024-11-01"),
+                dateEnd: undefined,
+                isCurrent: true,
+                location: "Seoul",
+                summary: "work summary",
+              },
+            },
+          ] as never
+        case "projects":
+          return [
+            {
+              data: {
+                title: "Data Grid",
+                company: "Exem",
+                description: "project summary",
+                techStack: ["React"],
+                link: undefined,
+                github: undefined,
+                dateStart: new Date("2025-01-01"),
+                dateEnd: undefined,
+                priority: 1,
+              },
+              body: "project body",
+            },
+          ] as never
+        case "education":
+          return [] as never
+        case "certificates":
+          return [] as never
+        case "awards":
+          return [] as never
+        case "skills":
+          return [
+            {
+              data: {
+                categories: [{ name: "Frontend", items: ["React"] }],
+              },
+            },
+          ] as never
+        default:
+          return [] as never
+      }
+    })
+
+    const blogPosts = [
+      {
+        title: "리액트 아키텍처 글",
+        url: "https://velog.io/@koreanthuglife/sample-post",
+        publishedAt: "2026-01-11T08:17:53.000Z",
+        summary: "요약",
+      },
+    ]
+    mockGetVelogPosts.mockResolvedValue(blogPosts)
+
+    const result = await serializeResumeData()
+
+    expect(mockGetVelogPosts).toHaveBeenCalledWith({ limit: 5 })
+    expect(result.blogPosts).toEqual(blogPosts)
+    expect(result.projects).toHaveLength(1)
+    expect(result.work).toHaveLength(1)
+  })
+})

--- a/web/tests/lib/resume-prompt/index.test.ts
+++ b/web/tests/lib/resume-prompt/index.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it, vi } from "vitest"
+
+const { mockGetCollection, mockGetVelogPosts } = vi.hoisted(() => ({
+  mockGetCollection: vi.fn(),
+  mockGetVelogPosts: vi.fn(),
+}))
+
+vi.mock("@/lib/blog/velog", () => ({
+  getVelogPosts: mockGetVelogPosts,
+}))
+
+vi.mock("astro:content", () => ({
+  getCollection: mockGetCollection,
+}))
+
+import { buildResumePrompt } from "../../../src/lib/resume-prompt"
+
+describe("buildResumePrompt", () => {
+  it("최근 블로그 글 섹션을 포함한다", async () => {
+    mockGetCollection.mockImplementation(async (collectionName) => {
+      switch (collectionName) {
+        case "basics":
+          return [
+            {
+              data: {
+                name: "최기환",
+                label: "Frontend Developer",
+                email: "test@example.com",
+                url: "https://resume-with-ai.gihwan-dev.com",
+                summary: "summary",
+                profiles: [],
+              },
+            },
+          ] as never
+        case "work":
+          return [] as never
+        case "projects":
+          return [] as never
+        case "education":
+          return [] as never
+        case "certificates":
+          return [] as never
+        case "awards":
+          return [] as never
+        default:
+          return [] as never
+      }
+    })
+
+    mockGetVelogPosts.mockResolvedValue([
+      {
+        title: "리액트로 바라보는 정책과 메커니즘의 분리",
+        url: "https://velog.io/@koreanthuglife/sample-post",
+        publishedAt: "2026-01-11T08:17:53.000Z",
+      },
+    ])
+
+    const prompt = await buildResumePrompt()
+
+    expect(mockGetVelogPosts).toHaveBeenCalledWith({ limit: 5 })
+    expect(prompt).toContain("## 최근 블로그 글")
+    expect(prompt).toContain("리액트로 바라보는 정책과 메커니즘의 분리")
+    expect(prompt).toContain("https://velog.io/@koreanthuglife/sample-post")
+  })
+
+  it("블로그 데이터가 없으면 최근 블로그 글 섹션을 생략한다", async () => {
+    mockGetCollection.mockImplementation(async (collectionName) => {
+      if (collectionName === "basics") {
+        return [
+          {
+            data: {
+              name: "최기환",
+              label: "Frontend Developer",
+              email: "test@example.com",
+              url: "https://resume-with-ai.gihwan-dev.com",
+              summary: "summary",
+              profiles: [],
+            },
+          },
+        ] as never
+      }
+
+      return [] as never
+    })
+
+    mockGetVelogPosts.mockResolvedValue([])
+
+    const prompt = await buildResumePrompt()
+
+    expect(prompt).not.toContain("## 최근 블로그 글")
+  })
+})

--- a/web/tests/mocks/astro-content.ts
+++ b/web/tests/mocks/astro-content.ts
@@ -1,0 +1,9 @@
+export async function getCollection(): Promise<never[]> {
+  return []
+}
+
+export async function render() {
+  return {
+    Content: () => null,
+  }
+}

--- a/web/vitest.config.ts
+++ b/web/vitest.config.ts
@@ -24,6 +24,7 @@ export default defineConfig(({ mode }) => {
     resolve: {
       alias: {
         "@": path.resolve(__dirname, "./src"),
+        "astro:content": path.resolve(__dirname, "./tests/mocks/astro-content.ts"),
       },
     },
   }


### PR DESCRIPTION
## 작업 요약\n- Velog RSS 기반 블로그 수집 모듈 추가(24시간 캐시 + stale fallback + inflight dedupe)\n- 이력서 웹에 Blog 섹션 추가(최신 5개, CTA, GA 이벤트)\n- 네비게이션/활성 섹션/section_view 트래킹에 blog 반영\n- PDF 데이터 타입/직렬화/문서 렌더링에 Blog 섹션 추가\n- AI 프롬프트(buildResumePrompt)에 최근 블로그 글 섹션 추가\n- blog/rss 직렬화/프롬프트 관련 테스트 추가\n\n## 검증\n- pnpm lint\n- pnpm test:run tests/lib/blog/velog.test.ts tests/lib/pdf/serialize-resume.test.ts tests/lib/resume-prompt/index.test.ts\n- pnpm build:vault\n- pnpm astro check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a Blog section to navigation
  * Integrated blog posts display on the resume and website, fetching from Velog RSS feed
  * Blog posts now included in PDF resume output with formatted dates and summaries
  * Implemented caching and error handling for blog post retrieval

* **Tests**
  * Added comprehensive test coverage for blog post fetching, caching logic, and resume integration

* **Chores**
  * Added fast-xml-parser dependency for RSS feed parsing

<!-- end of auto-generated comment: release notes by coderabbit.ai -->