### PR TITLE
feat: #78 첫 방문 사용자 대상 Chat 온보딩 v1 도입

### DIFF
--- a/web/e2e/chat-onboarding.spec.ts
+++ b/web/e2e/chat-onboarding.spec.ts
@@ -1,0 +1,162 @@
+import { expect, test } from "@playwright/test"
+import { mockApiRoutes } from "./fixtures/mock-api"
+import { waitForUiReady } from "./fixtures/ui-ready"
+
+type TrackedEvent = {
+  eventName: string
+  params?: Record<string, string | number | boolean | undefined>
+}
+
+const CHAT_ONBOARDING_STORAGE_KEY = "chat_onboarding_v1"
+const CHAT_ONBOARDING_VARIANT_STORAGE_KEY = "chat_onboarding_variant_v1"
+const CHAT_FIRST_VISIT_SEEN_AT_KEY = "chat_first_visit_seen_at"
+
+async function prepareTrackedPage(
+  page: import("@playwright/test").Page,
+  storage: Record<string, string> = {}
+) {
+  await page.addInitScript((initialStorage) => {
+    for (const [key, value] of Object.entries(initialStorage)) {
+      localStorage.setItem(key, value)
+    }
+
+    const trackedEvents: TrackedEvent[] = []
+    const trackedWindow = window as Window & {
+      __trackedGtagEvents?: TrackedEvent[]
+      gtag?: (
+        command: string,
+        eventName: string,
+        params?: Record<string, string | number | boolean | undefined>
+      ) => void
+      dataLayer?: unknown[]
+    }
+
+    trackedWindow.__trackedGtagEvents = trackedEvents
+    trackedWindow.dataLayer = []
+    trackedWindow.gtag = (
+      command: string,
+      eventName: string,
+      params?: Record<string, string | number | boolean | undefined>
+    ) => {
+      if (command !== "event") return
+      trackedEvents.push({ eventName, params })
+    }
+  }, storage)
+
+  await mockApiRoutes(page)
+  await page.goto("/")
+  await waitForUiReady(page)
+}
+
+async function getTrackedEvents(page: import("@playwright/test").Page) {
+  return page.evaluate(() => {
+    const trackedWindow = window as Window & {
+      __trackedGtagEvents?: TrackedEvent[]
+    }
+
+    return trackedWindow.__trackedGtagEvents ?? []
+  })
+}
+
+test.describe("Chat onboarding", () => {
+  test("first visit 카드 노출 + CTA open/focus + 첫 메시지 전송 시 completed 이벤트", async ({
+    page,
+  }) => {
+    await prepareTrackedPage(page)
+
+    const onboardingCard = page.getByTestId("chat-onboarding-card")
+    await expect(onboardingCard).toBeVisible()
+
+    await expect
+      .poll(async () => {
+        const trackedEvents = await getTrackedEvents(page)
+        return trackedEvents.filter((event) => event.eventName === "chat_onboarding_shown").length
+      })
+      .toBe(1)
+
+    await page.getByTestId("chat-onboarding-cta").click()
+    await expect(page.locator(".aui-modal-content")).toHaveAttribute("data-state", "open")
+    await expect(page.locator(".aui-composer-input")).toBeFocused()
+
+    const trackedAfterCta = await getTrackedEvents(page)
+    const ctaEvent = trackedAfterCta.find(
+      (event) => event.eventName === "chat_onboarding_cta_clicked"
+    )
+    expect(ctaEvent).toBeTruthy()
+    expect(ctaEvent?.params?.source).toBe("first_visit")
+    expect(["A", "B"]).toContain(String(ctaEvent?.params?.variant))
+    expect(["mobile", "desktop"]).toContain(String(ctaEvent?.params?.device))
+
+    await page.locator(".aui-composer-input").fill("안녕하세요")
+    await page.locator(".aui-composer-send").click()
+    await expect(page.getByText("최기환의 포트폴리오입니다.")).toBeVisible({ timeout: 10_000 })
+
+    await expect
+      .poll(
+        async () => {
+          const trackedEvents = await getTrackedEvents(page)
+          return trackedEvents.filter((event) => event.eventName === "chat_onboarding_completed")
+        },
+        { timeout: 10_000 }
+      )
+      .toHaveLength(1)
+
+    await expect(page.getByTestId("chat-onboarding-card")).toHaveCount(0)
+
+    const stateAfterFirstMessage = await page.evaluate(() => {
+      const raw = localStorage.getItem("chat_onboarding_v1")
+      return raw ? JSON.parse(raw) : null
+    })
+
+    expect(stateAfterFirstMessage?.status).toBe("completed")
+  })
+
+  for (const status of ["completed", "dismissed"] as const) {
+    test(`${status} 저장 상태에서는 온보딩 카드가 노출되지 않는다`, async ({ page }) => {
+      const savedState = JSON.stringify({
+        status,
+        source: "first_visit",
+        variant: "A",
+        completedAt: status === "completed" ? Date.now() : undefined,
+        dismissedAt: status === "dismissed" ? Date.now() : undefined,
+      })
+
+      await prepareTrackedPage(page, {
+        [CHAT_ONBOARDING_STORAGE_KEY]: savedState,
+        [CHAT_ONBOARDING_VARIANT_STORAGE_KEY]: "A",
+        [CHAT_FIRST_VISIT_SEEN_AT_KEY]: String(Date.now()),
+      })
+
+      await expect(page.getByTestId("chat-onboarding-card")).toHaveCount(0)
+
+      const trackedEvents = await getTrackedEvents(page)
+      expect(
+        trackedEvents.filter((event) => event.eventName === "chat_onboarding_shown")
+      ).toHaveLength(0)
+    })
+  }
+
+  test("dismiss 클릭 시 카드가 숨겨지고 dismissed 이벤트는 1회만 기록된다", async ({ page }) => {
+    await prepareTrackedPage(page)
+
+    const onboardingCard = page.getByTestId("chat-onboarding-card")
+    await expect(onboardingCard).toBeVisible()
+
+    await page.getByTestId("chat-onboarding-dismiss").click()
+    await expect(onboardingCard).toHaveCount(0)
+
+    await expect
+      .poll(async () => {
+        const trackedEvents = await getTrackedEvents(page)
+        return trackedEvents.filter((event) => event.eventName === "chat_onboarding_dismissed")
+      })
+      .toHaveLength(1)
+
+    const stateAfterDismiss = await page.evaluate(() => {
+      const raw = localStorage.getItem("chat_onboarding_v1")
+      return raw ? JSON.parse(raw) : null
+    })
+
+    expect(stateAfterDismiss?.status).toBe("dismissed")
+  })
+})

--- a/web/src/lib/chat-onboarding.ts
+++ b/web/src/lib/chat-onboarding.ts
@@ -1,0 +1,236 @@
+export type ChatOnboardingStatus = "never_shown" | "shown" | "dismissed" | "completed"
+export type ChatOnboardingSource = "first_visit" | "manual_reopen"
+export type ChatOnboardingVariant = "A" | "B"
+export type ChatOnboardingDevice = "mobile" | "desktop"
+
+export interface ChatOnboardingState {
+  status: ChatOnboardingStatus
+  shownAt?: number
+  dismissedAt?: number
+  completedAt?: number
+  source: ChatOnboardingSource
+  variant: ChatOnboardingVariant
+}
+
+type TrackingEventParams = Record<string, string | number | boolean | undefined>
+
+export const CHAT_ONBOARDING_STORAGE_KEY = "chat_onboarding_v1"
+export const CHAT_ONBOARDING_VARIANT_STORAGE_KEY = "chat_onboarding_variant_v1"
+export const CHAT_FIRST_VISIT_SEEN_AT_KEY = "chat_first_visit_seen_at"
+
+interface ShouldShowOnboardingArgs {
+  isFirstVisit: boolean
+  state: ChatOnboardingState | null
+}
+
+const VALID_STATUS = new Set<ChatOnboardingStatus>([
+  "never_shown",
+  "shown",
+  "dismissed",
+  "completed",
+])
+const VALID_SOURCE = new Set<ChatOnboardingSource>(["first_visit", "manual_reopen"])
+const VALID_VARIANT = new Set<ChatOnboardingVariant>(["A", "B"])
+
+function getStorage(): Storage | null {
+  if (typeof window === "undefined") {
+    return null
+  }
+
+  try {
+    return window.localStorage
+  } catch {
+    return null
+  }
+}
+
+function normalizeTimestamp(value: unknown): number | undefined {
+  return typeof value === "number" && Number.isFinite(value) ? value : undefined
+}
+
+function parseChatOnboardingState(raw: string | null): ChatOnboardingState | null {
+  if (!raw) {
+    return null
+  }
+
+  try {
+    const parsed = JSON.parse(raw) as Record<string, unknown>
+    const status = parsed.status
+    const source = parsed.source
+    const variant = parsed.variant
+
+    if (
+      !VALID_STATUS.has(status as ChatOnboardingStatus) ||
+      !VALID_SOURCE.has(source as ChatOnboardingSource) ||
+      !VALID_VARIANT.has(variant as ChatOnboardingVariant)
+    ) {
+      return null
+    }
+
+    return {
+      status: status as ChatOnboardingStatus,
+      source: source as ChatOnboardingSource,
+      variant: variant as ChatOnboardingVariant,
+      shownAt: normalizeTimestamp(parsed.shownAt),
+      dismissedAt: normalizeTimestamp(parsed.dismissedAt),
+      completedAt: normalizeTimestamp(parsed.completedAt),
+    }
+  } catch {
+    return null
+  }
+}
+
+function persistState(state: ChatOnboardingState): void {
+  const storage = getStorage()
+  if (!storage) {
+    return
+  }
+
+  try {
+    storage.setItem(CHAT_ONBOARDING_STORAGE_KEY, JSON.stringify(state))
+  } catch {
+    // no-op
+  }
+}
+
+function detectDevice(): ChatOnboardingDevice {
+  if (typeof window === "undefined") {
+    return "desktop"
+  }
+
+  return window.matchMedia("(max-width: 767px)").matches ? "mobile" : "desktop"
+}
+
+export function markFirstVisitSeen(): boolean {
+  const storage = getStorage()
+  if (!storage) {
+    return false
+  }
+
+  try {
+    const seenAt = storage.getItem(CHAT_FIRST_VISIT_SEEN_AT_KEY)
+    if (seenAt) {
+      return false
+    }
+
+    storage.setItem(CHAT_FIRST_VISIT_SEEN_AT_KEY, String(Date.now()))
+    return true
+  } catch {
+    return false
+  }
+}
+
+export function readChatOnboardingState(): ChatOnboardingState | null {
+  const storage = getStorage()
+  if (!storage) {
+    return null
+  }
+
+  try {
+    const raw = storage.getItem(CHAT_ONBOARDING_STORAGE_KEY)
+    const parsed = parseChatOnboardingState(raw)
+    if (!parsed && raw !== null) {
+      storage.removeItem(CHAT_ONBOARDING_STORAGE_KEY)
+    }
+    return parsed
+  } catch {
+    return null
+  }
+}
+
+export function writeChatOnboardingState(state: ChatOnboardingState): void {
+  persistState(state)
+}
+
+export function getOrAssignChatOnboardingVariant(): ChatOnboardingVariant {
+  const storage = getStorage()
+  const fallbackVariant: ChatOnboardingVariant = Math.random() < 0.5 ? "A" : "B"
+
+  if (!storage) {
+    return fallbackVariant
+  }
+
+  try {
+    const storedVariant = storage.getItem(CHAT_ONBOARDING_VARIANT_STORAGE_KEY)
+    if (storedVariant === "A" || storedVariant === "B") {
+      return storedVariant
+    }
+
+    storage.setItem(CHAT_ONBOARDING_VARIANT_STORAGE_KEY, fallbackVariant)
+    return fallbackVariant
+  } catch {
+    return fallbackVariant
+  }
+}
+
+export function shouldShowOnboarding({ isFirstVisit, state }: ShouldShowOnboardingArgs): boolean {
+  if (!isFirstVisit) {
+    return false
+  }
+
+  if (!state) {
+    return true
+  }
+
+  if (state.status === "dismissed" || state.status === "completed") {
+    return false
+  }
+
+  return state.status === "never_shown"
+}
+
+export function markOnboardingShown(args: {
+  source: ChatOnboardingSource
+  variant: ChatOnboardingVariant
+  at?: number
+}): ChatOnboardingState {
+  const nextState: ChatOnboardingState = {
+    status: "shown",
+    shownAt: args.at ?? Date.now(),
+    source: args.source,
+    variant: args.variant,
+  }
+
+  persistState(nextState)
+  return nextState
+}
+
+export function markOnboardingDismissed(
+  state: ChatOnboardingState,
+  at = Date.now()
+): ChatOnboardingState {
+  const nextState: ChatOnboardingState = {
+    ...state,
+    status: "dismissed",
+    dismissedAt: at,
+  }
+
+  persistState(nextState)
+  return nextState
+}
+
+export function markOnboardingCompleted(
+  state: ChatOnboardingState,
+  at = Date.now()
+): ChatOnboardingState {
+  const nextState: ChatOnboardingState = {
+    ...state,
+    status: "completed",
+    completedAt: at,
+  }
+
+  persistState(nextState)
+  return nextState
+}
+
+export function getOnboardingEventParams(
+  state: Pick<ChatOnboardingState, "variant" | "source">,
+  params: TrackingEventParams = {}
+): TrackingEventParams {
+  return {
+    device: detectDevice(),
+    variant: state.variant,
+    source: state.source,
+    ...params,
+  }
+}

--- a/web/tests/components/thread-suggestion.test.tsx
+++ b/web/tests/components/thread-suggestion.test.tsx
@@ -4,9 +4,10 @@ import { beforeEach, describe, expect, it, vi } from "vitest"
 import { ThreadWelcome } from "@/components/assistant-ui/thread"
 import { SUGGESTED_QUESTIONS } from "@/lib/chat-utils"
 
-const { appendSpy, trackEventSpy } = vi.hoisted(() => ({
+const { appendSpy, trackEventSpy, onUserMessageSubmittedSpy } = vi.hoisted(() => ({
   appendSpy: vi.fn(),
   trackEventSpy: vi.fn(),
+  onUserMessageSubmittedSpy: vi.fn(),
 }))
 
 vi.mock("@assistant-ui/react", async () => {
@@ -31,6 +32,7 @@ describe("ThreadWelcome 추천 질문", () => {
   beforeEach(() => {
     appendSpy.mockClear()
     trackEventSpy.mockClear()
+    onUserMessageSubmittedSpy.mockClear()
   })
 
   it("추천 질문 4개를 렌더링한다", () => {
@@ -43,13 +45,14 @@ describe("ThreadWelcome 추천 질문", () => {
   })
 
   it("추천 질문 클릭 시 analytics와 사용자 메시지 append를 호출한다", async () => {
-    render(<ThreadWelcome />)
+    render(<ThreadWelcome onUserMessageSubmitted={onUserMessageSubmittedSpy} />)
     const user = userEvent.setup()
     const firstQuestion = SUGGESTED_QUESTIONS[0]
 
     await user.click(screen.getByRole("button", { name: firstQuestion.text }))
 
     expect(trackEventSpy).toHaveBeenCalledWith("chat_message", { method: "suggestion" })
+    expect(onUserMessageSubmittedSpy).toHaveBeenCalledWith("suggestion")
     expect(appendSpy).toHaveBeenCalledWith({
       role: "user",
       content: [{ type: "text", text: firstQuestion.text }],

--- a/web/tests/lib/chat-onboarding.test.ts
+++ b/web/tests/lib/chat-onboarding.test.ts
@@ -1,0 +1,59 @@
+import { beforeEach, describe, expect, it, vi } from "vitest"
+import {
+  CHAT_FIRST_VISIT_SEEN_AT_KEY,
+  CHAT_ONBOARDING_STORAGE_KEY,
+  CHAT_ONBOARDING_VARIANT_STORAGE_KEY,
+  getOrAssignChatOnboardingVariant,
+  markFirstVisitSeen,
+  markOnboardingCompleted,
+  markOnboardingDismissed,
+  markOnboardingShown,
+  readChatOnboardingState,
+  shouldShowOnboarding,
+} from "@/lib/chat-onboarding"
+
+describe("chat onboarding storage utils", () => {
+  beforeEach(() => {
+    localStorage.clear()
+    vi.restoreAllMocks()
+  })
+
+  it("first visit 여부를 1회만 true로 판정한다", () => {
+    expect(markFirstVisitSeen()).toBe(true)
+    expect(markFirstVisitSeen()).toBe(false)
+    expect(localStorage.getItem(CHAT_FIRST_VISIT_SEEN_AT_KEY)).toBeTruthy()
+  })
+
+  it("variant를 최초 1회 고정한다", () => {
+    const randomSpy = vi.spyOn(Math, "random")
+    randomSpy.mockReturnValueOnce(0.1).mockReturnValueOnce(0.9)
+
+    const firstVariant = getOrAssignChatOnboardingVariant()
+    const secondVariant = getOrAssignChatOnboardingVariant()
+
+    expect(firstVariant).toBe("A")
+    expect(secondVariant).toBe("A")
+    expect(localStorage.getItem(CHAT_ONBOARDING_VARIANT_STORAGE_KEY)).toBe("A")
+  })
+
+  it("온보딩 노출 조건을 판정한다", () => {
+    expect(shouldShowOnboarding({ isFirstVisit: true, state: null })).toBe(true)
+    expect(shouldShowOnboarding({ isFirstVisit: false, state: null })).toBe(false)
+  })
+
+  it("dismissed/completed 상태는 재노출하지 않는다", () => {
+    const shownState = markOnboardingShown({ source: "first_visit", variant: "B" })
+    const dismissedState = markOnboardingDismissed(shownState)
+    const completedState = markOnboardingCompleted(shownState)
+
+    expect(shouldShowOnboarding({ isFirstVisit: true, state: dismissedState })).toBe(false)
+    expect(shouldShowOnboarding({ isFirstVisit: true, state: completedState })).toBe(false)
+  })
+
+  it("state parse 실패 시 null로 복구하고 저장값을 정리한다", () => {
+    localStorage.setItem(CHAT_ONBOARDING_STORAGE_KEY, "{invalid-json")
+
+    expect(readChatOnboardingState()).toBeNull()
+    expect(localStorage.getItem(CHAT_ONBOARDING_STORAGE_KEY)).toBeNull()
+  })
+})


### PR DESCRIPTION
## 변경 사항\n- first visit 기반 Chat 온보딩 상태/variant(localStorage) 유틸 추가\n- FAB 상단 온보딩 카드(CTA/dismiss) 및 shown/cta_clicked/dismissed/completed 이벤트 트래킹 추가\n- Thread에 온보딩 제어 props 및 사용자 메시지 제출 콜백 연결\n- Variant B에서 CTA 이후 예시 질문 3개 + composer 하이라이트 노출\n- 온보딩 단위 테스트 및 E2E 테스트 추가\n\n## 테스트\n- pnpm -C web run lint\n- pnpm -C web exec vitest run tests/lib/chat-onboarding.test.ts tests/components/thread-suggestion.test.tsx\n- CI=1 pnpm -C web exec playwright test e2e/chat-onboarding.spec.ts --project=chromium\n- CI=1 pnpm -C web exec playwright test e2e/chat-fab.spec.ts e2e/accessibility.spec.ts --project=chromium\n\n## 이슈\n- Closes #78

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced chat onboarding feature with an introductory card displayed on first visit
  * Users can dismiss the onboarding card or begin the guided flow
  * Onboarding state persists across sessions, preventing repeated prompts
  * A/B variant testing capability for optimizing the onboarding experience
  * Device detection (mobile/desktop) for adaptive onboarding presentation
  * Example prompts and composer highlighting guide users through initial chat

* **Tests**
  * Added comprehensive end-to-end tests for onboarding flows and state transitions
  * Enhanced test coverage for user message submission tracking

<!-- end of auto-generated comment: release notes by coderabbit.ai -->