### PR TITLE
feat(chat): Gemini 3.1 Pro 전환과 도구 정책 개선

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Overview
 
-AI-powered interactive resume site. An Astro + React SPA where a chat widget answers visitor questions about the owner's career by searching a local Obsidian vault via tool-calling agents (Gemini 2.5 Pro). Deployed on Vercel.
+AI-powered interactive resume site. An Astro + React SPA where a chat widget answers visitor questions about the owner's career by searching a local Obsidian vault via tool-calling agents (Gemini 3.1 Pro Preview). Deployed on Vercel.
 
 ## Commands
 
@@ -32,7 +32,7 @@ Monorepo root with `web/` containing the Astro app. `web/vault/` is a git submod
 
 - **Astro 5 + React 19** with `client:load` hydration
 - **Vercel AI SDK** (`ai` package) — `streamText`, `convertToModelMessages`, tool calling
-- **Google Vertex AI** — Gemini 2.5 Pro (chat), Gemini 2.0 Flash (followup)
+- **Google Vertex AI** — Gemini 3.1 Pro Preview on `global` endpoint (chat), Gemini 2.0 Flash (followup, `us-central1`)
 - **@assistant-ui/react** — Chat modal/thread primitives (wraps Radix Popover)
 - **TailwindCSS 4**, **Zustand**, **Zod**
 - **Biome** for linting/formatting (not ESLint), **Vitest** for tests
@@ -46,14 +46,15 @@ The core AI logic follows a multi-phase agent pattern:
 2. **Dynamic system prompt** — customizes persona and search strategy per intent
 3. **Agentic tool loop** (`pages/api/chat.ts`) — `streamText` with `prepareStep` callback controlling tool availability per step:
    - Step 0: search tools only (`toolChoice: "required"`)
-   - Step 1+: analyzes tool call patterns, enforces minimum search counts per intent, applies reflexion (excludes tool after 3+ consecutive same-tool calls)
+   - Step 1+: all tools enabled (`searchDocuments`, `readDocument`, `answer`) with `toolChoice: "auto"`
+   - Repetitive tool calls are handled with soft guidance in dynamic system prompt (no forced tool exclusion)
    - Loop ends on `hasToolCall("answer")` or `stepCountIs(15)`
 4. **Source validation** (`source-tracker.ts`) — `SearchContext` tracks all retrieved document IDs; `createAnswerTool` validates answer sources match actual search results to prevent hallucination
 
 Key modules:
 - `obsidian.server.ts` — searchDocuments, readDocument, buildCatalogSummary
 - `tools.ts` — AI SDK tool definitions (searchDocuments, readDocument, answer)
-- `prompts.ts` — classifyIntent, buildDynamicSystemPrompt, analyzeToolCallPattern, shouldAllowAnswer
+- `prompts.ts` — classifyIntent, buildDynamicSystemPrompt, analyzeToolCallPattern, resolveThinkingLevel
 - `source-tracker.ts` — createSearchContext, buildSearchContextFromSteps, validateSources
 
 ### API Routes

--- a/README.md
+++ b/README.md
@@ -12,6 +12,13 @@
 - 과거 상세 케이스 스터디 라우트(`/portfolio`, `/portfolio/*`)는 홈으로 리다이렉트됩니다.
 - AI 채팅, PDF 다운로드, 섹션 뷰 analytics는 유지됩니다.
 
+## AI 모델/도구 정책
+
+- 메인 채팅(`/api/chat`): Vertex AI `global` endpoint + `gemini-3.1-pro-preview`
+- 후속 질문(`/api/followup`): `gemini-2.0-flash` 유지
+- 도구 호출 정책: Step 0에서 검색 도구를 `required`로 강제하고, Step 1+는 `auto`로 모델이 `search/read/answer`를 자율 선택
+- 반복 도구 호출은 도구를 강제로 차단하지 않고 시스템 프롬프트에 soft guidance를 추가
+
 ## 아키텍처 개요
 
 ```mermaid

--- a/web/src/components/assistant-ui/thread.tsx
+++ b/web/src/components/assistant-ui/thread.tsx
@@ -23,6 +23,11 @@ import { Reasoning, ReasoningGroupWrapper } from "@/components/assistant-ui/reas
 import { ThinkingProcessProvider } from "@/components/assistant-ui/thinking-process"
 import { ToolCallStatus, ToolGroupWrapper } from "@/components/assistant-ui/tool-call-status"
 import { TooltipIconButton } from "@/components/assistant-ui/tooltip-icon-button"
+import {
+  AnswerMessageContent,
+  extractLatestAnswerToolArgs,
+  extractLatestCompletedAnswerToolArgs,
+} from "@/components/chat/answer-tool-ui"
 import { Button } from "@/components/ui/button"
 import { useFollowUp } from "@/hooks/use-follow-up"
 import { trackEvent } from "@/lib/analytics"
@@ -317,6 +322,7 @@ const AssistantMessage: FC<Pick<ThreadProps, "onUserMessageSubmitted">> = ({
             }}
           />
         </ThinkingProcessProvider>
+        <AnswerMessageBlock />
         <MessageError />
       </div>
 
@@ -326,6 +332,21 @@ const AssistantMessage: FC<Pick<ThreadProps, "onUserMessageSubmitted">> = ({
 
       <FollowUpSuggestions onUserMessageSubmitted={onUserMessageSubmitted} />
     </MessagePrimitive.Root>
+  )
+}
+
+const AnswerMessageBlock: FC = () => {
+  const message = useAuiState(({ message }) => message)
+  const answerArgs = extractLatestCompletedAnswerToolArgs(message.content, message.status?.type)
+  if (!answerArgs) return null
+
+  return (
+    <AnswerMessageContent
+      answer={answerArgs.answer}
+      sources={answerArgs.sources}
+      confidence={answerArgs.confidence}
+      className="px-2"
+    />
   )
 }
 
@@ -370,21 +391,8 @@ const FollowUpSuggestions: FC<Pick<ThreadProps, "onUserMessageSubmitted">> = ({
   useEffect(() => {
     if (!isLast || !isComplete || generatedRef.current) return
 
-    // 1차: answer tool call의 args.answer에서 추출
-    const answerPart = message.content.find(
-      (part) => part.type === "tool-call" && part.toolName === "answer"
-    )
-
-    let answerText = ""
-    if (
-      answerPart &&
-      answerPart.type === "tool-call" &&
-      answerPart.args &&
-      typeof answerPart.args === "object" &&
-      "answer" in answerPart.args
-    ) {
-      answerText = String((answerPart.args as Record<string, unknown>).answer)
-    }
+    const answerArgs = extractLatestAnswerToolArgs(message.content)
+    const answerText = answerArgs?.answer ?? ""
 
     // 2차 fallback: text 파트 (tool call 없는 경우 대비)
     const textContent =

--- a/web/src/components/chat/answer-tool-ui.tsx
+++ b/web/src/components/chat/answer-tool-ui.tsx
@@ -1,16 +1,32 @@
-import { makeAssistantToolUI } from "@assistant-ui/react"
+import Markdown from "react-markdown"
+import remarkGfm from "remark-gfm"
+import type { ComponentProps } from "react"
 import { sortSourcesBySection } from "@/lib/evidence-sort"
+import { cn } from "@/lib/utils"
 import { SourceCarousel } from "./source-carousel"
 import type { Source } from "./types"
 
-interface AnswerToolArgs {
+export interface AnswerSource {
+  type: "obsidian" | "resume"
+  title: string
+  id?: string
+}
+
+export interface AnswerToolArgs {
   answer: string
-  sources: {
-    type: "obsidian" | "resume"
-    title: string
-    id?: string
-  }[]
+  sources: AnswerSource[]
   confidence: "high" | "medium" | "low"
+}
+
+interface AnswerMessageContentProps extends AnswerToolArgs {
+  className?: string
+}
+
+interface ToolCallPartLike {
+  type: string
+  toolName?: string
+  args?: unknown
+  result?: unknown
 }
 
 const SOURCE_TYPE_LABELS: Record<string, string> = {
@@ -18,20 +34,131 @@ const SOURCE_TYPE_LABELS: Record<string, string> = {
   resume: "이력서",
 }
 
-export const AnswerToolUI = makeAssistantToolUI<AnswerToolArgs, unknown>({
-  toolName: "answer",
-  render: ({ args }) => {
-    if (!args?.sources?.length) return null
-
-    const sortedArgsSources = sortSourcesBySection(args.sources)
-
-    const sources: Source[] = sortedArgsSources.map((s, i) => ({
-      id: s.id ?? `source-${i}`,
-      title: s.title,
-      content: SOURCE_TYPE_LABELS[s.type] ?? s.type,
-      category: SOURCE_TYPE_LABELS[s.type] ?? s.type,
+function normalizeAnswerSources(value: unknown): AnswerSource[] {
+  if (!Array.isArray(value)) return []
+  return value
+    .filter((item): item is Record<string, unknown> => typeof item === "object" && item !== null)
+    .filter((item) => item.type === "obsidian" || item.type === "resume")
+    .filter((item) => typeof item.title === "string")
+    .map((item) => ({
+      type: item.type as "obsidian" | "resume",
+      title: item.title as string,
+      ...(typeof item.id === "string" ? { id: item.id } : {}),
     }))
+}
 
-    return <SourceCarousel sources={sources} />
-  },
-})
+export function extractLatestAnswerToolArgs(
+  content: ReadonlyArray<ToolCallPartLike>
+): AnswerToolArgs | null {
+  for (let i = content.length - 1; i >= 0; i--) {
+    const part = content[i]
+    if (part.type !== "tool-call" || part.toolName !== "answer") continue
+
+    const fromArgs = parseAnswerToolPayload(part.args)
+    if (fromArgs) return fromArgs
+
+    const fromResult = parseAnswerToolPayload(part.result)
+    if (fromResult) return fromResult
+  }
+
+  return null
+}
+
+export function extractLatestCompletedAnswerToolArgs(
+  content: ReadonlyArray<ToolCallPartLike>,
+  messageStatusType?: string
+): AnswerToolArgs | null {
+  if (messageStatusType !== "complete") return null
+  return extractLatestAnswerToolArgs(content)
+}
+
+function parseAnswerToolPayload(payload: unknown): AnswerToolArgs | null {
+  if (!payload || typeof payload !== "object") return null
+
+  const candidates: Array<Record<string, unknown>> = [payload as Record<string, unknown>]
+  const payloadRecord = payload as Record<string, unknown>
+
+  for (const nestedKey of ["output", "result", "data"] as const) {
+    const nested = payloadRecord[nestedKey]
+    if (nested && typeof nested === "object") {
+      candidates.push(nested as Record<string, unknown>)
+    }
+  }
+
+  for (const candidate of candidates) {
+    const answer = typeof candidate.answer === "string" ? candidate.answer.trim() : ""
+    if (!answer) continue
+
+    const confidence =
+      candidate.confidence === "high" ||
+      candidate.confidence === "medium" ||
+      candidate.confidence === "low"
+        ? candidate.confidence
+        : "low"
+
+    return {
+      answer,
+      sources: normalizeAnswerSources(candidate.sources),
+      confidence,
+    }
+  }
+
+  return null
+}
+
+function toSourceCarouselItems(answerSources: AnswerSource[]): Source[] {
+  const sortedAnswerSources = sortSourcesBySection(answerSources)
+  return sortedAnswerSources.map((source, index) => ({
+    id: source.id ?? `source-${index}`,
+    title: source.title,
+    content: SOURCE_TYPE_LABELS[source.type] ?? source.type,
+    category: SOURCE_TYPE_LABELS[source.type] ?? source.type,
+  }))
+}
+
+const answerMarkdownComponents = {
+  strong: ({ ...props }: ComponentProps<"strong">) => (
+    <strong className="font-semibold" {...props} />
+  ),
+  p: ({ ...props }: ComponentProps<"p">) => (
+    <p className="my-2 leading-relaxed first:mt-0 last:mb-0" {...props} />
+  ),
+  ul: ({ ...props }: ComponentProps<"ul">) => (
+    <ul className="my-2 ml-4 list-disc [&>li]:mt-1" {...props} />
+  ),
+  ol: ({ ...props }: ComponentProps<"ol">) => (
+    <ol className="my-2 ml-4 list-decimal [&>li]:mt-1" {...props} />
+  ),
+  li: ({ ...props }: ComponentProps<"li">) => <li className="leading-relaxed" {...props} />,
+  a: ({ ...props }: ComponentProps<"a">) => (
+    <a className="text-primary underline underline-offset-2 hover:text-primary/80" {...props} />
+  ),
+  code: ({ ...props }: ComponentProps<"code">) => (
+    <code
+      className="rounded-md border border-border/50 bg-muted/50 px-1 py-0.5 font-mono text-[0.85em]"
+      {...props}
+    />
+  ),
+}
+
+export function AnswerMessageContent({
+  answer,
+  sources,
+  className,
+}: AnswerMessageContentProps) {
+  const hasAnswer = answer.trim().length > 0
+  if (!hasAnswer) return null
+
+  const sourceItems = toSourceCarouselItems(sources)
+
+  return (
+    <div className={cn("mt-2", className)}>
+      <div className="text-sm text-foreground leading-relaxed">
+        <Markdown remarkPlugins={[remarkGfm]} components={answerMarkdownComponents}>
+          {answer}
+        </Markdown>
+      </div>
+      {sourceItems.length > 0 ? <SourceCarousel sources={sourceItems} /> : null}
+    </div>
+  )
+}

--- a/web/src/components/chat/chat-widget.tsx
+++ b/web/src/components/chat/chat-widget.tsx
@@ -2,7 +2,6 @@ import { useEffect } from "react"
 import { AssistantModal } from "@/components/assistant-ui/assistant-modal"
 import { CHAT_WIDGET_READY_EVENT } from "@/lib/layer-events"
 import { parseResumeVariant, type ResumeVariantId } from "@/lib/resume/variant"
-import { AnswerToolUI } from "./answer-tool-ui"
 import { ChatRuntimeProvider } from "./chat-runtime-provider"
 
 interface ChatWidgetProps {
@@ -29,7 +28,6 @@ export function ChatWidget({ resumeVariant = "frontend" }: ChatWidgetProps) {
 
   return (
     <ChatRuntimeProvider resumeVariant={normalizedResumeVariant}>
-      <AnswerToolUI />
       <AssistantModal />
     </ChatRuntimeProvider>
   )

--- a/web/src/lib/work-agent/index.ts
+++ b/web/src/lib/work-agent/index.ts
@@ -10,7 +10,7 @@ export {
   readDocumentContent,
   searchDocuments,
 } from "./obsidian.server"
-// Prompts (의도 분류, 반복 분석, 동적 프롬프트, 검색 충분성)
+// Prompts (의도 분류, 반복 분석, 동적 프롬프트, thinking level)
 export {
   analyzeToolCallPattern,
   buildDynamicSystemPrompt,
@@ -18,12 +18,11 @@ export {
   type DynamicPromptOptions,
   INTENT_KEYWORDS,
   type IntentClassification,
-  MIN_SEARCH_COUNT,
   PERSONA_PROMPTS,
   REFLEXION_PROTOCOL,
-  type SearchSufficiencyCheck,
+  resolveThinkingLevel,
   type StepAnalysis,
-  shouldAllowAnswer,
+  type ThinkingLevel,
   type ToolCallHistory,
   type UserIntent,
 } from "./prompts"

--- a/web/src/lib/work-agent/prompts.ts
+++ b/web/src/lib/work-agent/prompts.ts
@@ -1,6 +1,6 @@
 /**
  * Work Agent 프롬프트 모듈
- * 의도 분류, 반복 호출 분석, 동적 프롬프트 생성
+ * 의도 분류, 반복 호출 분석, 동적 프롬프트/Thinking Level 생성
  * Obsidian 볼트 기반 아키텍처
  */
 
@@ -35,29 +35,11 @@ export interface DynamicPromptOptions {
   includeReflexion?: boolean
 }
 
-export interface SearchSufficiencyCheck {
-  isReady: boolean
-  currentCount: number
-  minRequired: number
-  reason: string
-}
+export type ThinkingLevel = "high" | "low"
 
 // ============================================
 // 상수 정의
 // ============================================
-
-/**
- * 의도별 최소 검색 횟수
- * - contact_inquiry: 연락처는 이력서에 있으므로 최소 1회
- * - career_inquiry/technical_inquiry: searchDocuments + readDocument
- * - general_chat: 최소한의 확인
- */
-export const MIN_SEARCH_COUNT: Record<UserIntent, number> = {
-  career_inquiry: 2, // searchDocuments + readDocument
-  technical_inquiry: 2, // searchDocuments + readDocument
-  contact_inquiry: 1, // 이력서 정보로 충분
-  general_chat: 1, // 최소한의 확인
-}
 
 /**
  * 의도별 키워드 매핑
@@ -194,62 +176,42 @@ export const INTENT_KEYWORDS: Record<UserIntent, string[]> = {
  * 의도별 페르소나 프롬프트
  */
 export const PERSONA_PROMPTS: Record<UserIntent, string> = {
-  career_inquiry: `## 현재 모드: 커리어 상담가
+  career_inquiry: `## 모드: 커리어 답변
+- 먼저 searchDocuments로 근거를 찾고, 필요한 문서는 readDocument로 확인하세요.
+- 답변은 문제/해결/성과 순서로 간결하게 작성하세요.
+- 확인되지 않은 수치나 사실은 추측하지 마세요.`,
 
-사용자가 경력/프로젝트 관련 질문을 했습니다. 다음 지침을 따르세요:
+  technical_inquiry: `## 모드: 기술 답변
+- 기술 질문은 반드시 검색 근거를 확보한 뒤 답변하세요.
+- 문서 제목만으로 단정하지 말고, 구현 세부는 readDocument로 검증하세요.
+- 설명은 기술 선택 이유와 구현 포인트 중심으로 작성하세요.`,
 
-1. **검색 전략**: Exem 업무 기록을 우선 검색하여 실제 업무 내용 파악
-2. **답변 스타일**: 구체적인 업무 경험과 성과 중심으로 답변
-3. **상세 조회 필수**: searchDocuments로 관련 문서 찾은 후 반드시 readDocument로 내용 확인`,
+  contact_inquiry: `## 모드: 연락처 안내
+- 공개된 이력서/볼트 정보만 사용하세요.
+- 정보가 없으면 없다고 명확히 말하세요.
+- 짧고 직접적으로 안내하세요.`,
 
-  technical_inquiry: `## 현재 모드: 기술 전문가
-
-사용자가 기술적 질문을 했습니다. 다음 지침을 따르세요:
-
-1. **검색 전략**: 기술 카테고리와 업무 기록을 함께 검색
-2. **답변 스타일**: 기술적으로 정확하고 구체적인 설명 제공
-3. **코드/구현 언급**: 가능하면 사용된 기술과 구현 방식 설명
-4. **상세 조회 필수**: searchDocuments 결과에서 유망한 문서는 반드시 readDocument로 확인`,
-
-  contact_inquiry: `## 현재 모드: 연결 담당자
-
-사용자가 연락처/연결 관련 질문을 했습니다. 다음 지침을 따르세요:
-
-1. **검색 전략**: 검색 최소화, 이력서 정보로 충분
-2. **답변 스타일**: 친절하게 연락처 정보 안내
-3. **정보 범위**: 이력서에 있는 공개 정보만 제공
-4. **추가 안내**: 필요시 GitHub, LinkedIn 등 프로필 링크 안내`,
-
-  general_chat: `## 현재 모드: 친근한 어시스턴트
-
-사용자가 일반적인 대화를 시작했습니다. 다음 지침을 따르세요:
-
-1. **검색 전략**: 질문 내용에 따라 유연하게 판단
-2. **답변 스타일**: 친근하고 도움이 되는 톤 유지
-3. **안내**: 더 구체적인 질문이 있으면 도움 가능함을 안내
-4. **자연스러움**: 로봇처럼 느껴지지 않게 자연스럽게 대화`,
+  general_chat: `## 모드: 일반 대화
+- 사실성 질문은 검색 후 답변하세요.
+- 잡담은 간결하고 자연스럽게 응답하세요.
+- 근거가 없으면 추측하지 마세요.`,
 }
 
 /**
- * Reflexion 프로토콜: 반복 호출 감지 시 사용
+ * 반복 호출 시 전략 전환 힌트(soft guidance)
  */
-export const REFLEXION_PROTOCOL = `## ⚠️ 반복 호출 감지
+export const REFLEXION_PROTOCOL = `## 전략 전환 힌트
+- 동일한 도구 호출이 반복되고 있습니다.
+- 이전 쿼리를 그대로 반복하지 말고 키워드를 바꾸거나 다른 문서를 읽으세요.
+- 충분한 근거가 모이면 answer 도구로 마무리하세요.
+- 근거가 부족하면 "확인되지 않음"으로 답변하세요.`
 
-동일한 도구가 3회 연속 호출되었습니다. 다음 지침을 따르세요:
-
-### 자기 성찰 (Reflexion)
-1. **이전 검색 결과 검토**: 지금까지 찾은 정보가 충분한지 평가
-2. **접근 방식 변경**: 다른 키워드나 다른 도구 사용 고려
-3. **종료 판단**: 충분한 정보가 있으면 answer 도구로 답변
-
-### 대안 전략
-- 다른 키워드로 검색 시도
-- searchDocuments와 readDocument를 번갈아 활용
-- 검색 결과가 없다면 이력서 기본 정보로 답변
-
-### 주의
-- 같은 검색을 반복하지 마세요
-- 정보를 찾지 못했다면 솔직히 답변하세요`
+export function resolveThinkingLevel(intent: UserIntent): ThinkingLevel {
+  if (intent === "career_inquiry" || intent === "technical_inquiry") {
+    return "high"
+  }
+  return "low"
+}
 
 // ============================================
 // 함수 정의
@@ -410,37 +372,10 @@ export function buildDynamicSystemPrompt(options: DynamicPromptOptions): string 
 ### 이전 검색 쿼리
 ${options.analysis.lastQueries.map((q, i) => `${i + 1}. "${q}"`).join("\n")}
 
-**위 쿼리와 다른 접근을 시도하세요.**`)
+위 쿼리와 다른 접근을 시도하세요.`)
       }
     }
   }
 
   return parts.join("\n\n")
-}
-
-/**
- * 검색 충분성을 확인하여 answer 도구 허용 여부를 결정합니다.
- */
-export function shouldAllowAnswer(
-  intent: UserIntent,
-  analysis: StepAnalysis
-): SearchSufficiencyCheck {
-  const minRequired = MIN_SEARCH_COUNT[intent]
-  const currentCount = analysis.totalSearchCount
-
-  if (currentCount < minRequired) {
-    return {
-      isReady: false,
-      currentCount,
-      minRequired,
-      reason: `최소 검색 미달: ${currentCount}/${minRequired}회 (의도: ${intent})`,
-    }
-  }
-
-  return {
-    isReady: true,
-    currentCount,
-    minRequired,
-    reason: `검색 충족: ${currentCount}/${minRequired}회 이상 완료`,
-  }
 }

--- a/web/src/pages/api/chat.ts
+++ b/web/src/pages/api/chat.ts
@@ -20,8 +20,8 @@ import {
   classifyIntent,
   createAnswerTool,
   createSearchContext,
+  resolveThinkingLevel,
   type SearchContext,
-  shouldAllowAnswer,
   workAgentTools,
 } from "@/lib/work-agent"
 import { buildCatalogSummary } from "@/lib/work-agent/obsidian.server"
@@ -33,131 +33,22 @@ const ALL_TOOLS: ToolName[] = [...SEARCH_TOOLS, "answer"]
 
 const SYSTEM_PROMPT_HEADER = `당신은 최기환의 이력서 웹사이트에서 방문자의 질문에 답변하는 AI 어시스턴트입니다.
 
-## 역할
-- 아래 이력서 정보와 Obsidian 볼트 문서를 기반으로 최기환에 대한 질문에 답변
-- 이력서와 볼트에 없는 정보는 "해당 정보는 확인되지 않았습니다"라고 답변
-
-## 답변 스타일
-- 한국어로 답변
-- 간결하고 명확하게
-- 필요시 마크다운 사용
-
-## 데이터 소스
-모든 정보는 로컬 Obsidian 볼트에서 검색됩니다. 외부 API 호출이 없으므로 빠르고 안정적입니다.
-
-### 업무 기록 (Exem 디렉토리)
-- Exem 카테고리의 문서에는 실제 업무 기록이 담겨 있습니다
-- Projects: 프로젝트별 TODO, 설계, 아키텍처
-- Daily: 일일 업무 기록, 회의록
-- Knowledge: 업무 중 습득한 지식
-- Snippets: 재사용 코드 스니펫
-- Archive: 과거 프로젝트 기록
-
-### 기술 지식
-- React.js, JavaScript, TypeScript, CSS, HTML 등 프론트엔드 기술
-- Browser, Network 등 시스템 지식
-- Clean Code, FSD, Design System 등 아키텍처/패턴
-- AI, Algorithm, Test 등 기타 기술`
+## 핵심 원칙
+- 제공된 이력서/Obsidian 볼트 근거만 사용하세요.
+- 근거가 없으면 "해당 정보는 확인되지 않았습니다"라고 답하세요.
+- 한국어로 간결하고 직접적으로 답하세요.
+- 사실성 질문은 searchDocuments/readDocument 결과를 확인한 뒤 답하세요.`
 
 const SYSTEM_PROMPT_FOOTER = `## 도구 사용 전략
 
-### 기본 원칙
-- **모든 질문에 대해 먼저 검색 수행**: 이력서 기본 정보로 답변 가능해 보여도, 볼트에서 더 상세한 정보 검색
-- 충분한 정보를 얻을 때까지 여러 번 검색 가능
-- 검색 결과가 부족하면 다른 키워드로 재시도
-- 검색 완료 후 이력서 정보와 검색 결과를 종합하여 답변
-
-### 검색 워크플로우
-1. **초기 검색**: 질문의 핵심 키워드로 searchDocuments 검색
-2. **상세 조회 (필수!)**:
-   - searchDocuments 결과에서 관련 문서 발견 시 **반드시** readDocument로 전체 내용 확인
-   - searchDocuments는 메타데이터만 반환, 실제 내용은 readDocument로 조회 필수
-   - **핵심**: 문서 제목만으로 답변하지 말고, 상세 내용 확인 후 답변
-3. **보완 검색**: 정보가 부족하면:
-   - 다른 키워드로 재검색 (예: "데이터 그리드" → "DataGrid" → "테이블 컴포넌트")
-   - Exem 업무 기록과 기술 지식 카테고리를 함께 검색
-4. **종합**: 여러 문서의 정보를 종합하여 답변
-
-### 도구별 활용
-1. **searchDocuments**: 키워드로 볼트 문서 검색 (제목, 카테고리, 태그, 요약에서 매칭)
-2. **readDocument**: searchDocuments에서 찾은 문서의 전체 내용 조회
-
-### 검색 품질 기준
-- 질문에 직접 답변할 수 있는 구체적 정보를 찾을 때까지 검색
-- 검색 결과가 0건이거나 관련성이 낮으면 반드시 재검색
-- "정보를 찾을 수 없다"고 답변하기 전에 최소 2-3가지 다른 접근 시도
-
-### answer 도구 사용 가이드
-- **반드시 검색 후 사용**: 최소 1회 이상 검색을 수행한 후에만 answer 도구 사용
-- **출처 명시**: 검색 결과에서 정보를 찾았다면 sources에 포함
-
-### 채용 관점 응답 가이드 (필수)
-- 답변은 가능한 한 "문제 → 해결 → 성과(정량)" 순서로 작성
-- 정량 성과는 searchDocuments/readDocument로 확인된 수치만 사용
-- 수치 근거가 없으면 "정량 수치 미확인"을 명시
-- 질문이 모호하면 내부적으로 채용 관점 질문으로 리라이팅한 뒤 답변
-  - 답변 첫 줄에 "해석 기준: ..." 형식으로 해석 기준을 짧게 노출
-- answer.sources는 아래 우선순위로 정렬
-  1. 프로젝트 (project)
-  2. 경력 (career)
-  3. 기술스택 (tech_stack)
-
-### 채용 관점 대표 답변 예시 (스타일 참조)
-1. 접근성(WCAG)
-   - 문제: 키보드 탐색과 스크린리더 사용성이 낮음
-   - 해결: ARIA 속성 보강, 포커스 순서/대비 개선, 접근성 테스트 도입
-   - 성과(정량): 접근성 점수 상승 또는 이슈 감소 (없으면 "정량 수치 미확인")
-2. TypeScript 안정성/품질
-   - 문제: 런타임 오류와 타입 불일치가 잦음
-   - 해결: 타입 모델 정리, strict 규칙 강화, 회귀 테스트 보완
-   - 성과(정량): 오류 건수/재발률/리뷰 지적 감소 (없으면 "정량 수치 미확인")
-3. AI 도구 활용 경험
-   - 문제: 반복적인 문서화/분석/개발 속도 병목
-   - 해결: AI 기반 초안 생성 + 수동 검증 프로세스 구축
-   - 성과(정량): 작성 시간 단축, 반복 작업 감소 (없으면 "정량 수치 미확인")
-4. 디자인 시스템/컴포넌트 설계
-   - 문제: UI 일관성 부족과 컴포넌트 중복
-   - 해결: 재사용 가능한 컴포넌트/토큰 체계 정립
-   - 성과(정량): 중복 코드 감소, 개발 리드타임 개선 (없으면 "정량 수치 미확인")
-5. 메타 프레임워크/SSR/서버리스
-   - 문제: 초기 로딩/배포 운영 효율 이슈
-   - 해결: SSR/정적 렌더링/서버리스 라우트 설계 최적화
-   - 성과(정량): 응답속도 개선, 배포 안정성 향상 (없으면 "정량 수치 미확인")
-
-### confidence 기반 답변 포맷 (필수!)
-
-**high (검색 결과에서 직접 확인)**:
-- 그대로 답변하되 출처를 명시
-- 예: "DataGrid 컴포넌트는 TanStack Virtual 기반으로 구현되었습니다."
-
-**medium (부분적 정보만 확인)**:
-- 반드시 "검색 결과에 따르면"으로 시작
-- 예: "검색 결과에 따르면 해당 기능은 개발 중입니다."
-
-**low (이력서 기반 추론 또는 정보 없음)**:
-- **절대 추측하지 말 것**
-- "해당 질문에 대한 구체적인 정보를 찾지 못했습니다."
-
-### answer 도구 출처 규칙 (중요!)
-- sources에는 검색 결과에서 받은 **실제 ID**를 반드시 포함
-  - Obsidian 문서: searchDocuments/readDocument에서 받은 id
-  - resume 타입만 id 없이 사용 가능
-- 시스템이 자동으로 출처 ID가 실제 검색 결과와 일치하는지 검증
-- 검색되지 않은 ID를 출처로 지정하면 경고 발생
-
-### 출처 작성 예시
-
-**올바른 예시:**
-{
-  "sources": [
-    { "type": "obsidian", "title": "위젯 빌더 리팩토링", "id": "Exem--01-Projects--차세대-대시보드--위젯빌더--위젯-빌더-리팩토링" },
-    { "type": "resume", "title": "이력서 기본 정보" }
-  ]
-}
-
-### 주의사항
-- 도구 호출 실패 시 에러 메시지에 따라 대응
-- 같은 검색을 반복하지 마세요`
+- searchDocuments는 후보 탐색, readDocument는 본문 검증 용도입니다.
+- 문서 제목만으로 단정하지 말고 필요한 문서는 readDocument로 확인하세요.
+- 반복 검색이면 키워드/접근을 바꿔 재시도하세요.
+- 최종 응답은 반드시 answer 도구로 작성하고, sources에는 실제 검색 결과 ID만 포함하세요.
+- confidence 규칙:
+  - high: 검색 결과로 직접 확인됨
+  - medium: 일부만 확인됨("검색 결과에 따르면"으로 시작)
+  - low: 근거 부족(추측 금지, 확인되지 않았다고 답변)`
 
 /**
  * Content Collections 데이터를 기반으로 시스템 프롬프트를 동적 생성
@@ -189,6 +80,10 @@ ${catalogSummary}
 ${SYSTEM_PROMPT_FOOTER}${dynamicSection}`
 }
 
+function appendDynamicPrompt(basePrompt: string, dynamicPrompt: string): string {
+  return `${basePrompt}\n\n---\n\n${dynamicPrompt}`
+}
+
 // Lazy initialization: Vertex AI 인스턴스를 요청 시점에 생성
 const getVertex = () => {
   const privateKey = import.meta.env.FIREBASE_PRIVATE_KEY
@@ -206,7 +101,7 @@ const getVertex = () => {
 
   return createVertex({
     project: projectId,
-    location: "us-central1",
+    location: "global",
     googleAuthOptions: {
       credentials: {
         client_email: clientEmail,
@@ -214,6 +109,12 @@ const getVertex = () => {
       },
     },
   })
+}
+
+function hasAnswerToolCall(
+  steps: Array<{ toolCalls?: Array<{ toolName: string; args?: unknown }> }>
+): boolean {
+  return steps.some((step) => step.toolCalls?.some((call) => call.toolName === "answer"))
 }
 
 export const POST = async ({ request }: { request: Request }) => {
@@ -248,7 +149,9 @@ export const POST = async ({ request }: { request: Request }) => {
     const initialDynamicPrompt = buildDynamicSystemPrompt({
       intent: intentClassification.intent,
     })
-    const systemPrompt = await getSystemPrompt(resumeVariant, initialDynamicPrompt)
+    const baseSystemPrompt = await getSystemPrompt(resumeVariant)
+    const systemPrompt = appendDynamicPrompt(baseSystemPrompt, initialDynamicPrompt)
+    const thinkingLevel = resolveThinkingLevel(intentClassification.intent)
 
     // SearchContext 추적: 검색된 모든 ID를 누적
     let currentSearchContext: SearchContext = createSearchContext()
@@ -264,11 +167,12 @@ export const POST = async ({ request }: { request: Request }) => {
     }
 
     const result = streamText({
-      model: vertex("gemini-2.5-pro"),
+      model: vertex("gemini-3.1-pro-preview"),
       providerOptions: {
         google: {
           thinkingConfig: {
             includeThoughts: true,
+            thinkingLevel,
           },
         },
       },
@@ -288,16 +192,13 @@ export const POST = async ({ request }: { request: Request }) => {
 
         // 도구 호출 패턴 분석
         const analysis = analyzeToolCallPattern(steps)
+        const dynamicPrompt = buildDynamicSystemPrompt({
+          intent: intentClassification.intent,
+          analysis,
+          includeReflexion: true,
+        })
+        const stepSystemPrompt = appendDynamicPrompt(baseSystemPrompt, dynamicPrompt)
 
-        // Step 0: 검색 도구만 활성화, 필수 사용
-        if (stepNumber === 0) {
-          return {
-            activeTools: SEARCH_TOOLS,
-            toolChoice: "required" as const,
-          }
-        }
-
-        // 3회 연속 동일 도구 호출 시 해당 도구 제외 (ReAct + Reflexion)
         if (analysis.consecutiveSameToolCount >= 3 && analysis.lastToolName) {
           console.warn(
             "[Repetitive Tool Call]",
@@ -307,30 +208,29 @@ export const POST = async ({ request }: { request: Request }) => {
               lastQueries: analysis.lastQueries,
             })
           )
-
-          // 반복된 도구를 제외한 대안 도구 목록
-          const alternativeTools = ALL_TOOLS.filter((t) => t !== analysis.lastToolName)
-
-          return {
-            activeTools: alternativeTools,
-            toolChoice: "required" as const,
-          }
         }
 
-        // 검색 충분성 확인: 의도별 최소 검색 횟수 충족 여부
-        const sufficiency = shouldAllowAnswer(intentClassification.intent, analysis)
-
-        if (!sufficiency.isReady) {
-          // 최소 검색 미달 → 검색 도구만, 필수 사용
-          console.log("[Search Sufficiency]", sufficiency.reason)
+        // Step 0: 검색 도구만 활성화, 필수 사용
+        if (stepNumber === 0) {
           return {
+            system: stepSystemPrompt,
             activeTools: SEARCH_TOOLS,
             toolChoice: "required" as const,
           }
         }
 
-        // 최소 검색 충족 → answer 포함 모든 도구 활성화
+        const answered = hasAnswerToolCall(steps)
+        if (!answered && stepNumber >= 2) {
+          return {
+            system: stepSystemPrompt,
+            activeTools: ["answer"],
+            toolChoice: "required" as const,
+          }
+        }
+
+        // Step 1+: answer 포함 모든 도구 자동 선택
         return {
+          system: stepSystemPrompt,
           activeTools: ALL_TOOLS,
           toolChoice: "auto" as const,
         }

--- a/web/tests/components/chat/answer-tool-ui.test.tsx
+++ b/web/tests/components/chat/answer-tool-ui.test.tsx
@@ -1,0 +1,141 @@
+import { render, screen } from "@testing-library/react"
+import { describe, expect, it, vi } from "vitest"
+import {
+  AnswerMessageContent,
+  extractLatestAnswerToolArgs,
+  extractLatestCompletedAnswerToolArgs,
+} from "@/components/chat/answer-tool-ui"
+
+vi.mock("@/components/chat/source-carousel", () => ({
+  SourceCarousel: ({ sources }: { sources: Array<{ id: string }> }) => (
+    <div data-testid="source-carousel">{`sources:${sources.length}`}</div>
+  ),
+}))
+
+describe("extractLatestAnswerToolArgs", () => {
+  it("마지막 answer tool-call args를 추출한다", () => {
+    const result = extractLatestAnswerToolArgs([
+      {
+        type: "tool-call",
+        toolName: "answer",
+        args: {
+          answer: "초기 답변",
+          sources: [],
+          confidence: "low",
+        },
+      },
+      {
+        type: "tool-call",
+        toolName: "searchDocuments",
+        args: { query: "접근성" },
+      },
+      {
+        type: "tool-call",
+        toolName: "answer",
+        args: {
+          answer: "최종 답변",
+          sources: [{ type: "resume", title: "이력서" }],
+          confidence: "high",
+        },
+      },
+    ])
+
+    expect(result).toMatchObject({
+      answer: "최종 답변",
+      confidence: "high",
+    })
+    expect(result?.sources).toHaveLength(1)
+  })
+
+  it("유효한 answer 문자열이 없으면 null을 반환한다", () => {
+    const result = extractLatestAnswerToolArgs([
+      {
+        type: "tool-call",
+        toolName: "answer",
+        args: {
+          answer: "",
+          sources: [],
+          confidence: "low",
+        },
+      },
+    ])
+
+    expect(result).toBeNull()
+  })
+
+  it("args가 없어도 result에 answer가 있으면 추출한다", () => {
+    const result = extractLatestAnswerToolArgs([
+      {
+        type: "tool-call",
+        toolName: "answer",
+        result: {
+          answer: "result 기반 답변",
+          sources: [{ type: "obsidian", title: "문서 A" }],
+          confidence: "medium",
+        },
+      },
+    ])
+
+    expect(result).toMatchObject({
+      answer: "result 기반 답변",
+      confidence: "medium",
+    })
+    expect(result?.sources).toHaveLength(1)
+  })
+})
+
+describe("extractLatestCompletedAnswerToolArgs", () => {
+  const content = [
+    {
+      type: "tool-call",
+      toolName: "answer",
+      args: {
+        answer: "완료 후 노출 답변",
+        sources: [],
+        confidence: "low",
+      },
+    },
+  ] as const
+
+  it("메시지 상태가 complete가 아니면 null을 반환한다", () => {
+    expect(extractLatestCompletedAnswerToolArgs(content, "running")).toBeNull()
+    expect(extractLatestCompletedAnswerToolArgs(content, undefined)).toBeNull()
+  })
+
+  it("메시지 상태가 complete면 answer를 추출한다", () => {
+    const result = extractLatestCompletedAnswerToolArgs(content, "complete")
+    expect(result?.answer).toBe("완료 후 노출 답변")
+  })
+})
+
+describe("AnswerMessageContent", () => {
+  it("sources가 없어도 answer 본문을 렌더링한다", () => {
+    render(
+      <AnswerMessageContent
+        answer={"**핵심 결과**\n\n- 접근성 수치 미확인"}
+        sources={[]}
+        confidence="low"
+      />
+    )
+
+    expect(screen.getByText("핵심 결과")).toBeTruthy()
+    expect(screen.getByText("접근성 수치 미확인")).toBeTruthy()
+    expect(screen.queryByTestId("source-carousel")).toBeNull()
+  })
+
+  it("sources가 있으면 source carousel을 함께 렌더링한다", () => {
+    render(
+      <AnswerMessageContent
+        answer="최종 답변"
+        sources={[
+          { type: "resume", title: "이력서" },
+          { type: "obsidian", title: "프로젝트 문서", id: "doc-1" },
+        ]}
+        confidence="high"
+      />
+    )
+
+    expect(screen.getByText("최종 답변")).toBeTruthy()
+    expect(screen.getByTestId("source-carousel").textContent).toContain("sources:2")
+  })
+})

--- a/web/tests/lib/work-agent/prompts.test.ts
+++ b/web/tests/lib/work-agent/prompts.test.ts
@@ -10,10 +10,9 @@ import {
   buildDynamicSystemPrompt,
   classifyIntent,
   INTENT_KEYWORDS,
-  MIN_SEARCH_COUNT,
   PERSONA_PROMPTS,
   REFLEXION_PROTOCOL,
-  shouldAllowAnswer,
+  resolveThinkingLevel,
   type UserIntent,
 } from "../../../src/lib/work-agent/prompts"
 
@@ -172,28 +171,28 @@ describe("prompts", () => {
   describe("buildDynamicSystemPrompt", () => {
     it("career_inquiry 의도에 맞는 프롬프트 생성", () => {
       const result = buildDynamicSystemPrompt({ intent: "career_inquiry" })
-      expect(result).toContain("커리어 상담가")
-      expect(result).toContain("Exem 업무 기록을 우선 검색")
+      expect(result).toContain("모드: 커리어 답변")
+      expect(result).toContain("문제/해결/성과")
     })
 
     it("technical_inquiry 의도에 맞는 프롬프트 생성", () => {
       const result = buildDynamicSystemPrompt({ intent: "technical_inquiry" })
-      expect(result).toContain("기술 전문가")
-      expect(result).toContain("기술 카테고리")
+      expect(result).toContain("모드: 기술 답변")
+      expect(result).toContain("문서 제목만으로 단정하지 말고")
     })
 
     it("contact_inquiry 의도에 맞는 프롬프트 생성", () => {
       const result = buildDynamicSystemPrompt({ intent: "contact_inquiry" })
-      expect(result).toContain("연결 담당자")
-      expect(result).toContain("검색 최소화")
+      expect(result).toContain("모드: 연락처 안내")
+      expect(result).toContain("공개된 이력서/볼트 정보")
     })
 
     it("general_chat 의도에 맞는 프롬프트 생성", () => {
       const result = buildDynamicSystemPrompt({ intent: "general_chat" })
-      expect(result).toContain("친근한 어시스턴트")
+      expect(result).toContain("모드: 일반 대화")
     })
 
-    it("반복 호출 감지 시 Reflexion 프로토콜 추가", () => {
+    it("반복 호출 감지 시 soft guidance를 추가한다", () => {
       const analysis = {
         consecutiveSameToolCount: 3,
         lastToolName: "searchDocuments",
@@ -205,8 +204,8 @@ describe("prompts", () => {
         analysis,
         includeReflexion: true,
       })
-      expect(result).toContain("반복 호출 감지")
-      expect(result).toContain("자기 성찰")
+      expect(result).toContain("전략 전환 힌트")
+      expect(result).toContain("동일한 도구 호출이 반복")
       expect(result).toContain("이전 검색 쿼리")
       expect(result).toContain("query1")
       expect(result).toContain("query2")
@@ -225,7 +224,7 @@ describe("prompts", () => {
         analysis,
         includeReflexion: true,
       })
-      expect(result).not.toContain("반복 호출 감지")
+      expect(result).not.toContain("전략 전환 힌트")
     })
 
     it("includeReflexion false면 Reflexion 미포함", () => {
@@ -240,90 +239,22 @@ describe("prompts", () => {
         analysis,
         includeReflexion: false,
       })
-      expect(result).not.toContain("반복 호출 감지")
+      expect(result).not.toContain("전략 전환 힌트")
     })
   })
 
   // ============================================
-  // shouldAllowAnswer Tests
+  // resolveThinkingLevel Tests
   // ============================================
-  describe("shouldAllowAnswer", () => {
-    const createAnalysis = (totalSearchCount: number) => ({
-      consecutiveSameToolCount: 0,
-      lastToolName: null,
-      lastQueries: [],
-      totalSearchCount,
+  describe("resolveThinkingLevel", () => {
+    it("technical/career 의도는 high", () => {
+      expect(resolveThinkingLevel("technical_inquiry")).toBe("high")
+      expect(resolveThinkingLevel("career_inquiry")).toBe("high")
     })
 
-    describe("career_inquiry (최소 2회)", () => {
-      it("검색 0회: 미달", () => {
-        const result = shouldAllowAnswer("career_inquiry", createAnalysis(0))
-        expect(result.isReady).toBe(false)
-        expect(result.currentCount).toBe(0)
-        expect(result.minRequired).toBe(2)
-        expect(result.reason).toContain("최소 검색 미달")
-      })
-
-      it("검색 1회: 미달", () => {
-        const result = shouldAllowAnswer("career_inquiry", createAnalysis(1))
-        expect(result.isReady).toBe(false)
-        expect(result.currentCount).toBe(1)
-        expect(result.minRequired).toBe(2)
-      })
-
-      it("검색 2회: 충족", () => {
-        const result = shouldAllowAnswer("career_inquiry", createAnalysis(2))
-        expect(result.isReady).toBe(true)
-        expect(result.currentCount).toBe(2)
-        expect(result.reason).toContain("검색 충족")
-      })
-
-      it("검색 5회: 충족", () => {
-        const result = shouldAllowAnswer("career_inquiry", createAnalysis(5))
-        expect(result.isReady).toBe(true)
-        expect(result.currentCount).toBe(5)
-      })
-    })
-
-    describe("contact_inquiry (최소 1회)", () => {
-      it("검색 0회: 미달", () => {
-        const result = shouldAllowAnswer("contact_inquiry", createAnalysis(0))
-        expect(result.isReady).toBe(false)
-        expect(result.minRequired).toBe(1)
-      })
-
-      it("검색 1회: 충족", () => {
-        const result = shouldAllowAnswer("contact_inquiry", createAnalysis(1))
-        expect(result.isReady).toBe(true)
-        expect(result.currentCount).toBe(1)
-        expect(result.minRequired).toBe(1)
-      })
-    })
-
-    describe("general_chat (최소 1회)", () => {
-      it("검색 0회: 미달", () => {
-        const result = shouldAllowAnswer("general_chat", createAnalysis(0))
-        expect(result.isReady).toBe(false)
-        expect(result.minRequired).toBe(1)
-      })
-
-      it("검색 1회: 충족", () => {
-        const result = shouldAllowAnswer("general_chat", createAnalysis(1))
-        expect(result.isReady).toBe(true)
-      })
-    })
-
-    describe("technical_inquiry (최소 2회)", () => {
-      it("검색 1회: 미달", () => {
-        const result = shouldAllowAnswer("technical_inquiry", createAnalysis(1))
-        expect(result.isReady).toBe(false)
-        expect(result.minRequired).toBe(2)
-      })
-
-      it("검색 2회: 충족", () => {
-        const result = shouldAllowAnswer("technical_inquiry", createAnalysis(2))
-        expect(result.isReady).toBe(true)
-      })
+    it("contact/general 의도는 low", () => {
+      expect(resolveThinkingLevel("contact_inquiry")).toBe("low")
+      expect(resolveThinkingLevel("general_chat")).toBe("low")
     })
   })
 
@@ -359,27 +290,7 @@ describe("prompts", () => {
 
     it("REFLEXION_PROTOCOL이 정의됨", () => {
       expect(REFLEXION_PROTOCOL).toBeDefined()
-      expect(REFLEXION_PROTOCOL).toContain("반복 호출 감지")
-    })
-
-    it("MIN_SEARCH_COUNT에 모든 의도 정의됨", () => {
-      const intents: UserIntent[] = [
-        "career_inquiry",
-        "technical_inquiry",
-        "contact_inquiry",
-        "general_chat",
-      ]
-      for (const intent of intents) {
-        expect(MIN_SEARCH_COUNT[intent]).toBeDefined()
-        expect(MIN_SEARCH_COUNT[intent]).toBeGreaterThanOrEqual(1)
-      }
-    })
-
-    it("MIN_SEARCH_COUNT 값이 의도에 맞게 설정됨", () => {
-      expect(MIN_SEARCH_COUNT.contact_inquiry).toBe(1) // 연락처: 최소
-      expect(MIN_SEARCH_COUNT.general_chat).toBe(1) // 일반: 최소
-      expect(MIN_SEARCH_COUNT.career_inquiry).toBe(2) // 경력: searchDocuments + readDocument
-      expect(MIN_SEARCH_COUNT.technical_inquiry).toBe(2) // 기술: searchDocuments + readDocument
+      expect(REFLEXION_PROTOCOL).toContain("전략 전환 힌트")
     })
   })
 })

--- a/web/tests/pages/api/chat.test.ts
+++ b/web/tests/pages/api/chat.test.ts
@@ -10,9 +10,12 @@ const {
   mockCaptureException,
   mockFlush,
   mockClassifyIntent,
+  mockAnalyzeToolCallPattern,
   mockBuildDynamicSystemPrompt,
   mockCreateSearchContext,
   mockCreateAnswerTool,
+  mockResolveThinkingLevel,
+  mockVertexModel,
 } = vi.hoisted(() => ({
   mockBuildResumePrompt: vi.fn(),
   mockBuildCatalogSummary: vi.fn(),
@@ -23,9 +26,12 @@ const {
   mockCaptureException: vi.fn(),
   mockFlush: vi.fn(),
   mockClassifyIntent: vi.fn(),
+  mockAnalyzeToolCallPattern: vi.fn(),
   mockBuildDynamicSystemPrompt: vi.fn(),
   mockCreateSearchContext: vi.fn(),
   mockCreateAnswerTool: vi.fn(),
+  mockResolveThinkingLevel: vi.fn(),
+  mockVertexModel: vi.fn(() => "mock-model"),
 }))
 
 vi.mock("@/lib/resume-prompt", () => ({
@@ -41,17 +47,13 @@ vi.mock("@/lib/stream/filter-tool-input-delta", () => ({
 }))
 
 vi.mock("@/lib/work-agent", () => ({
-  analyzeToolCallPattern: () => ({
-    consecutiveSameToolCount: 0,
-    lastToolName: undefined,
-    lastQueries: [],
-  }),
+  analyzeToolCallPattern: mockAnalyzeToolCallPattern,
   buildDynamicSystemPrompt: mockBuildDynamicSystemPrompt,
   buildSearchContextFromSteps: () => ({ searchedIds: [] }),
   classifyIntent: mockClassifyIntent,
   createAnswerTool: mockCreateAnswerTool,
   createSearchContext: mockCreateSearchContext,
-  shouldAllowAnswer: () => ({ isReady: true, reason: "ok" }),
+  resolveThinkingLevel: mockResolveThinkingLevel,
   workAgentTools: {
     searchDocuments: { description: "search" },
     readDocument: { description: "read" },
@@ -92,22 +94,38 @@ describe("/api/chat", () => {
     mockCaptureException.mockReset()
     mockFlush.mockReset()
     mockClassifyIntent.mockReset()
+    mockAnalyzeToolCallPattern.mockReset()
     mockBuildDynamicSystemPrompt.mockReset()
     mockCreateSearchContext.mockReset()
     mockCreateAnswerTool.mockReset()
+    mockResolveThinkingLevel.mockReset()
+    mockVertexModel.mockReset()
 
     mockBuildResumePrompt.mockResolvedValue("resume prompt")
     mockBuildCatalogSummary.mockReturnValue("catalog summary")
     mockConvertToModelMessages.mockResolvedValue([])
     mockClassifyIntent.mockReturnValue({
-      intent: "experience",
+      intent: "technical_inquiry",
       confidence: 0.9,
       keywords: ["AI"],
     })
-    mockBuildDynamicSystemPrompt.mockReturnValue("dynamic prompt")
+    mockAnalyzeToolCallPattern.mockReturnValue({
+      consecutiveSameToolCount: 0,
+      lastToolName: null,
+      lastQueries: [],
+      totalSearchCount: 0,
+    })
+    mockBuildDynamicSystemPrompt.mockImplementation((options?: { analysis?: { lastQueries?: string[] } }) => {
+      const queries = options?.analysis?.lastQueries ?? []
+      return queries.length > 0
+        ? `soft guidance\n이전 검색 쿼리\n${queries.map((q) => `"${q}"`).join("\n")}`
+        : "dynamic prompt"
+    })
     mockCreateSearchContext.mockReturnValue({})
     mockCreateAnswerTool.mockReturnValue({ description: "answer" })
-    mockCreateVertex.mockReturnValue(() => "mock-model")
+    mockResolveThinkingLevel.mockReturnValue("high")
+    mockVertexModel.mockReturnValue("mock-model")
+    mockCreateVertex.mockReturnValue(mockVertexModel)
     mockStreamText.mockReturnValue({
       toUIMessageStream: () => new ReadableStream(),
     })
@@ -143,5 +161,166 @@ describe("/api/chat", () => {
 
     expect(response.status).toBe(200)
     expect(mockBuildResumePrompt).toHaveBeenCalledWith("frontend")
+  })
+
+  it("Gemini 3.1 Pro + global endpoint + intent 기반 thinkingLevel을 사용한다", async () => {
+    const response = await POST({
+      request: new Request("http://localhost/api/chat?variant=frontend", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          messages: [{ role: "user", parts: [{ type: "text", text: "기술 스택 설명해줘" }] }],
+        }),
+      }),
+    })
+
+    expect(response.status).toBe(200)
+    expect(mockCreateVertex).toHaveBeenCalledWith(
+      expect.objectContaining({
+        location: "global",
+      })
+    )
+    expect(mockResolveThinkingLevel).toHaveBeenCalledWith("technical_inquiry")
+    expect(mockVertexModel).toHaveBeenCalledWith("gemini-3.1-pro-preview")
+    expect(mockStreamText).toHaveBeenCalledWith(
+      expect.objectContaining({
+        providerOptions: {
+          google: {
+            thinkingConfig: {
+              includeThoughts: true,
+              thinkingLevel: "high",
+            },
+          },
+        },
+      })
+    )
+  })
+
+  it("prepareStep 정책이 Step0 required / Step1 auto 로 동작한다", async () => {
+    await POST({
+      request: new Request("http://localhost/api/chat?variant=frontend", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          messages: [{ role: "user", parts: [{ type: "text", text: "프로젝트 알려줘" }] }],
+        }),
+      }),
+    })
+
+    const streamTextArg = mockStreamText.mock.calls[0][0] as {
+      prepareStep: (args: { stepNumber: number; steps: Array<{ toolCalls?: Array<{ toolName: string }> }> }) => {
+        system: string
+        activeTools: string[]
+        toolChoice: "required" | "auto"
+      }
+    }
+    const step0 = streamTextArg.prepareStep({ stepNumber: 0, steps: [] })
+    const step1 = streamTextArg.prepareStep({ stepNumber: 1, steps: [] })
+
+    expect(step0.toolChoice).toBe("required")
+    expect(step0.activeTools).toEqual(["searchDocuments", "readDocument"])
+    expect(step1.toolChoice).toBe("auto")
+    expect(step1.activeTools).toEqual(["searchDocuments", "readDocument", "answer"])
+  })
+
+  it("answer 미호출 상태에서 step2+는 answer required 가드가 동작한다", async () => {
+    await POST({
+      request: new Request("http://localhost/api/chat?variant=frontend", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          messages: [{ role: "user", parts: [{ type: "text", text: "경력 알려줘" }] }],
+        }),
+      }),
+    })
+
+    const streamTextArg = mockStreamText.mock.calls[0][0] as {
+      prepareStep: (args: { stepNumber: number; steps: Array<{ toolCalls?: Array<{ toolName: string }> }> }) => {
+        activeTools: string[]
+        toolChoice: "required" | "auto"
+      }
+    }
+
+    const step2WithoutAnswer = streamTextArg.prepareStep({
+      stepNumber: 2,
+      steps: [{ toolCalls: [{ toolName: "searchDocuments" }] }],
+    })
+    expect(step2WithoutAnswer.toolChoice).toBe("required")
+    expect(step2WithoutAnswer.activeTools).toEqual(["answer"])
+
+    const step2WithAnswer = streamTextArg.prepareStep({
+      stepNumber: 2,
+      steps: [{ toolCalls: [{ toolName: "answer" }] }],
+    })
+    expect(step2WithAnswer.toolChoice).toBe("auto")
+    expect(step2WithAnswer.activeTools).toEqual(["searchDocuments", "readDocument", "answer"])
+  })
+
+  it("반복 호출 3회 이상이면 prepareStep.system에 soft guidance와 이전 쿼리가 포함된다", async () => {
+    mockAnalyzeToolCallPattern.mockReturnValueOnce({
+      consecutiveSameToolCount: 3,
+      lastToolName: "searchDocuments",
+      lastQueries: ["query1", "query2", "query3"],
+      totalSearchCount: 3,
+    })
+
+    await POST({
+      request: new Request("http://localhost/api/chat?variant=frontend", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          messages: [{ role: "user", parts: [{ type: "text", text: "검색해줘" }] }],
+        }),
+      }),
+    })
+
+    const streamTextArg = mockStreamText.mock.calls[0][0] as {
+      prepareStep: (args: { stepNumber: number; steps: Array<{ toolCalls?: Array<{ toolName: string }> }> }) => {
+        system: string
+      }
+    }
+    const step1 = streamTextArg.prepareStep({
+      stepNumber: 1,
+      steps: [{ toolCalls: [{ toolName: "searchDocuments" }] }],
+    })
+
+    expect(step1.system).toContain("soft guidance")
+    expect(step1.system).toContain("이전 검색 쿼리")
+    expect(step1.system).toContain("\"query1\"")
+    expect(step1.system).toContain("\"query2\"")
+    expect(step1.system).toContain("\"query3\"")
+  })
+
+  it("contact_inquiry 에서는 thinkingLevel low를 사용한다", async () => {
+    mockClassifyIntent.mockReturnValueOnce({
+      intent: "contact_inquiry",
+      confidence: 0.8,
+      keywords: ["연락처"],
+    })
+    mockResolveThinkingLevel.mockReturnValueOnce("low")
+
+    await POST({
+      request: new Request("http://localhost/api/chat?variant=frontend", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          messages: [{ role: "user", parts: [{ type: "text", text: "연락처 알려줘" }] }],
+        }),
+      }),
+    })
+
+    expect(mockResolveThinkingLevel).toHaveBeenCalledWith("contact_inquiry")
+    expect(mockStreamText).toHaveBeenCalledWith(
+      expect.objectContaining({
+        providerOptions: {
+          google: {
+            thinkingConfig: {
+              includeThoughts: true,
+              thinkingLevel: "low",
+            },
+          },
+        },
+      })
+    )
   })
 })


### PR DESCRIPTION
## 요약
- 메인 채팅 모델을 `gemini-3.1-pro-preview`와 Vertex `global` endpoint로 전환
- intent 기반 `thinkingLevel`과 하이브리드 tool policy 적용
- `answer` 종료 가드와 source validation 계약 유지
- Gemini 3 스타일에 맞게 프롬프트/테스트/문서 정리

## 검증
- `pnpm test:run`
- `pnpm typecheck`
- `pnpm build`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Upgraded AI model to Gemini 3.1 Pro Preview for improved performance
  * Introduced dynamic system prompts tailored per conversation step
  * Enhanced answer rendering with source carousel display

* **Improvements**
  * Changed API endpoint to global location for better availability
  * Relaxed tool usage policy—all tools automatically available from step 1 onward
  * Improved answer extraction and message content handling
  * Refined prompt guidance for multi-step interactions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->