### PR TITLE
feat(work-agent): Obsidian 벡터 하이브리드 검색 + wiki 링크 연쇄 탐색 + 풀텍스트 프리뷰

### DIFF
--- a/web/.gitignore
+++ b/web/.gitignore
@@ -10,6 +10,9 @@ lighthouse/
 .vercel/
 next-env.d.ts
 
+# Local caches
+scripts/cache/
+
 # Environment Variables
 .env
 .env.*

--- a/web/scripts/build-vault.mjs
+++ b/web/scripts/build-vault.mjs
@@ -4,19 +4,36 @@
  * Vercel 서버리스 함수에서 런타임 파일시스템 스캔 없이 동작하도록 함
  */
 
+import "dotenv/config"
 import { execFileSync } from "node:child_process"
 import fs from "node:fs"
 import path from "node:path"
+import { createVertex } from "@ai-sdk/google-vertex"
+import { embedMany } from "ai"
 import MiniSearch from "minisearch"
 import {
   buildPathActivityMapFromGitLog,
   detectInitialVaultCommitHash,
 } from "./live-feed-activity-utils.mjs"
 import { extractVaultDateMeta } from "./vault-date-utils.mjs"
+import {
+  generateEmbeddings,
+  loadEmbeddingCache,
+  saveEmbeddingCache,
+} from "./vault-embedding-utils.mjs"
+import { buildDocIndex, parseWikiLinks, resolveWikiTarget } from "./vault-wiki-link-utils.mjs"
 
 const VAULT_PATH = path.join(process.cwd(), "vault")
 const OUTPUT_PATH = path.join(process.cwd(), "src", "generated", "vault-data.json")
 const SEARCH_INDEX_PATH = path.join(process.cwd(), "src", "generated", "search-index.json")
+const EMBEDDINGS_PATH = path.join(process.cwd(), "src", "generated", "vault-embeddings.json")
+const EMBEDDING_CACHE_PATH = path.join(
+  process.cwd(),
+  "scripts",
+  "cache",
+  "vault-embedding-cache.json"
+)
+const EMBEDDING_MODEL_ID = "text-embedding-005"
 
 function resolveGitRoot() {
   try {
@@ -146,6 +163,7 @@ function scanVault(dir, pathActivityMap) {
 
       const { eventDate, updatedAt } = extractVaultDateMeta(rawContent, normalizedRelativePath)
       const activityAt = pathActivityMap.get(normalizedRelativePath)
+      const { outLinks: outLinksRaw, imageLinks: imageLinksRaw } = parseWikiLinks(content)
 
       documents.push({
         id: createDocumentId(normalizedRelativePath),
@@ -158,6 +176,8 @@ function scanVault(dir, pathActivityMap) {
         eventDate,
         updatedAt,
         activityAt,
+        outLinksRaw,
+        imageLinks: imageLinksRaw.map((link) => link.target),
       })
     }
   }
@@ -187,15 +207,84 @@ if (feedCandidates.length === 0) {
   )
 }
 
+// Wiki 링크 해석 + 역링크 인덱스
+const catalogForIndex = new Map(
+  documents.map((doc) => [doc.id, { id: doc.id, category: doc.category, title: doc.title }])
+)
+const docIndex = buildDocIndex(documents)
+
+const ambiguousLinkTargets = new Set()
+for (const doc of documents) {
+  const resolvedOutLinks = []
+  const seen = new Set()
+  for (const link of doc.outLinksRaw ?? []) {
+    const resolvedId = resolveWikiTarget(link.target, docIndex, {
+      sourceCategory: doc.category,
+      catalog: catalogForIndex,
+      onAmbiguous: (target) => ambiguousLinkTargets.add(target),
+    })
+    if (!resolvedId || resolvedId === doc.id || seen.has(resolvedId)) continue
+    seen.add(resolvedId)
+    resolvedOutLinks.push(resolvedId)
+  }
+  doc.outLinks = resolvedOutLinks
+  delete doc.outLinksRaw
+}
+
+const inLinksMap = new Map()
+for (const doc of documents) {
+  for (const targetId of doc.outLinks) {
+    const existing = inLinksMap.get(targetId)
+    if (existing) {
+      existing.add(doc.id)
+    } else {
+      inLinksMap.set(targetId, new Set([doc.id]))
+    }
+  }
+}
+for (const doc of documents) {
+  doc.inLinks = Array.from(inLinksMap.get(doc.id) ?? [])
+}
+
+if (ambiguousLinkTargets.size > 0) {
+  console.warn(
+    `[build-vault] Ambiguous wiki targets resolved by first match: ${Array.from(
+      ambiguousLinkTargets
+    )
+      .slice(0, 10)
+      .join(
+        ", "
+      )}${ambiguousLinkTargets.size > 10 ? ` (+${ambiguousLinkTargets.size - 10} more)` : ""}`
+  )
+}
+
+const totalOutLinks = documents.reduce((sum, doc) => sum + doc.outLinks.length, 0)
+console.log(
+  `[build-vault] Wiki graph: ${totalOutLinks} out-links across ${documents.length} documents`
+)
+
+// 임베딩 생성
+const embeddingCache = loadEmbeddingCache(EMBEDDING_CACHE_PATH)
+const embeddingsMap = await buildEmbeddingMap(documents, embeddingCache)
+
 // 출력 디렉토리 생성
 fs.mkdirSync(path.dirname(OUTPUT_PATH), { recursive: true })
 
-// JSON 파일 생성
+// vault-data.json (메타 + 본문 + 링크 그래프, 임베딩은 별도 파일)
 fs.writeFileSync(OUTPUT_PATH, JSON.stringify({ documents }, null, 0))
 
 const sizeKB = (fs.statSync(OUTPUT_PATH).size / 1024).toFixed(1)
 console.log(`[build-vault] Built vault data: ${documents.length} documents (${sizeKB} KB)`)
 console.log(`[build-vault] Live Resume Feed candidates: ${feedCandidates.length}`)
+
+// 임베딩 JSON (없으면 빈 객체 — 런타임에서 BM25로 fallback)
+const embeddingsObject = {}
+for (const [docId, vector] of embeddingsMap) embeddingsObject[docId] = vector
+fs.writeFileSync(EMBEDDINGS_PATH, JSON.stringify(embeddingsObject))
+const embeddingsSizeKB = (fs.statSync(EMBEDDINGS_PATH).size / 1024).toFixed(1)
+console.log(
+  `[build-vault] Built embeddings: ${Object.keys(embeddingsObject).length} vectors (${embeddingsSizeKB} KB)`
+)
 
 // MiniSearch 인덱스 빌드
 const miniSearch = new MiniSearch({
@@ -229,3 +318,46 @@ fs.writeFileSync(SEARCH_INDEX_PATH, JSON.stringify(miniSearch))
 
 const indexSizeKB = (fs.statSync(SEARCH_INDEX_PATH).size / 1024).toFixed(1)
 console.log(`[build-vault] Built search index: ${documents.length} documents (${indexSizeKB} KB)`)
+
+async function buildEmbeddingMap(docs, cache) {
+  const privateKey = process.env.FIREBASE_PRIVATE_KEY
+  const clientEmail = process.env.FIREBASE_CLIENT_EMAIL
+  const projectId = process.env.PUBLIC_FIREBASE_PROJECT_ID
+
+  if (!privateKey || !clientEmail || !projectId) {
+    console.warn(
+      "[embedding] Missing FIREBASE_* env vars. Skipping embeddings — BM25 fallback will be used at runtime."
+    )
+    return new Map()
+  }
+
+  const vertex = createVertex({
+    project: projectId,
+    location: "global",
+    googleAuthOptions: {
+      credentials: {
+        client_email: clientEmail,
+        private_key: privateKey.replace(/\\n/g, "\n"),
+      },
+    },
+  })
+  const model = vertex.textEmbeddingModel(EMBEDDING_MODEL_ID)
+
+  const {
+    embeddings,
+    cache: updatedCache,
+    regenerated,
+    failed,
+  } = await generateEmbeddings({
+    documents: docs,
+    cache,
+    embedMany,
+    model,
+  })
+
+  saveEmbeddingCache(EMBEDDING_CACHE_PATH, updatedCache)
+  console.log(
+    `[embedding] ${embeddings.size} vectors ready (regenerated ${regenerated}, failed ${failed})`
+  )
+  return embeddings
+}

--- a/web/scripts/vault-embedding-utils.mjs
+++ b/web/scripts/vault-embedding-utils.mjs
@@ -1,0 +1,132 @@
+import crypto from "node:crypto"
+import fs from "node:fs"
+import path from "node:path"
+
+const EMBED_INPUT_CHAR_LIMIT = 8000
+const DEFAULT_BATCH_SIZE = 100
+const RETRY_DELAYS_MS = [1000, 2000, 4000]
+
+export function computeContentHash(doc) {
+  return crypto.createHash("sha1").update(`${doc.title}\n${doc.content}`).digest("hex")
+}
+
+export function buildEmbeddingInput(doc) {
+  const body =
+    doc.content.length > EMBED_INPUT_CHAR_LIMIT
+      ? doc.content.slice(0, EMBED_INPUT_CHAR_LIMIT)
+      : doc.content
+  return `${doc.title}\n\n${body}`
+}
+
+export function loadEmbeddingCache(cachePath) {
+  try {
+    const raw = fs.readFileSync(cachePath, "utf-8")
+    const parsed = JSON.parse(raw)
+    if (parsed && typeof parsed === "object") return parsed
+  } catch {
+    // 파일 없음/손상은 캐시 미스로 처리
+  }
+  return {}
+}
+
+export function saveEmbeddingCache(cachePath, cache) {
+  fs.mkdirSync(path.dirname(cachePath), { recursive: true })
+  fs.writeFileSync(cachePath, JSON.stringify(cache))
+}
+
+export function normalizeVector(vector) {
+  let norm = 0
+  for (const value of vector) norm += value * value
+  norm = Math.sqrt(norm)
+  if (norm === 0) return vector.slice()
+  const normalized = new Array(vector.length)
+  for (let i = 0; i < vector.length; i++) normalized[i] = vector[i] / norm
+  return normalized
+}
+
+async function sleep(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms))
+}
+
+async function embedBatchWithRetry(values, embedMany, model) {
+  for (let attempt = 0; attempt <= RETRY_DELAYS_MS.length; attempt++) {
+    try {
+      const { embeddings } = await embedMany({ model, values })
+      return embeddings
+    } catch (error) {
+      if (attempt === RETRY_DELAYS_MS.length) {
+        throw error
+      }
+      const delay = RETRY_DELAYS_MS[attempt]
+      console.warn(
+        `[embedding] Batch failed (attempt ${attempt + 1}/${RETRY_DELAYS_MS.length + 1}): ${
+          error?.message ?? error
+        }. Retrying in ${delay}ms.`
+      )
+      await sleep(delay)
+    }
+  }
+  throw new Error("embedBatchWithRetry exhausted")
+}
+
+export async function generateEmbeddings({
+  documents,
+  cache,
+  embedMany,
+  model,
+  batchSize = DEFAULT_BATCH_SIZE,
+}) {
+  const results = new Map()
+  const freshCache = { ...cache }
+  const pending = []
+
+  for (const doc of documents) {
+    const hash = computeContentHash(doc)
+    const cached = cache[doc.id]
+    if (
+      cached &&
+      cached.hash === hash &&
+      Array.isArray(cached.embedding) &&
+      cached.embedding.length > 0
+    ) {
+      results.set(doc.id, cached.embedding)
+      continue
+    }
+    pending.push({ doc, hash })
+  }
+
+  if (pending.length === 0) {
+    return { embeddings: results, cache: freshCache, regenerated: 0, failed: 0 }
+  }
+
+  let regenerated = 0
+  let failed = 0
+
+  for (let i = 0; i < pending.length; i += batchSize) {
+    const batch = pending.slice(i, i + batchSize)
+    const values = batch.map(({ doc }) => buildEmbeddingInput(doc))
+    try {
+      const vectors = await embedBatchWithRetry(values, embedMany, model)
+      batch.forEach(({ doc, hash }, index) => {
+        const vector = vectors[index]
+        if (!Array.isArray(vector) || vector.length === 0) {
+          failed += 1
+          return
+        }
+        const normalized = normalizeVector(vector)
+        results.set(doc.id, normalized)
+        freshCache[doc.id] = { hash, embedding: normalized }
+        regenerated += 1
+      })
+    } catch (error) {
+      failed += batch.length
+      console.error(
+        `[embedding] Batch ${i / batchSize + 1} failed permanently: ${
+          error?.message ?? error
+        }. Affected documents will fall back to BM25-only.`
+      )
+    }
+  }
+
+  return { embeddings: results, cache: freshCache, regenerated, failed }
+}

--- a/web/scripts/vault-wiki-link-utils.mjs
+++ b/web/scripts/vault-wiki-link-utils.mjs
@@ -1,0 +1,111 @@
+const WIKI_LINK_PATTERN = /(!?)\[\[([^[\]\n]+?)(?:\|([^[\]\n]+?))?\]\]/g
+const IMAGE_EXTENSION_PATTERN = /\.(png|jpe?g|gif|svg|webp|bmp|avif)$/i
+
+export function parseWikiLinks(content) {
+  if (typeof content !== "string" || content.length === 0) {
+    return { outLinks: [], imageLinks: [] }
+  }
+
+  const outLinks = []
+  const imageLinks = []
+
+  for (const match of content.matchAll(WIKI_LINK_PATTERN)) {
+    const [, embedMark, rawTarget, alias] = match
+    const embed = embedMark === "!"
+    const normalizedTarget = stripAnchorsAndBlocks(rawTarget).trim()
+    if (!normalizedTarget) continue
+
+    const entry = {
+      target: normalizedTarget,
+      display: typeof alias === "string" ? alias.trim() : undefined,
+    }
+
+    if (embed && IMAGE_EXTENSION_PATTERN.test(normalizedTarget)) {
+      imageLinks.push(entry)
+    } else if (!embed) {
+      outLinks.push(entry)
+    }
+  }
+
+  return { outLinks, imageLinks }
+}
+
+function stripAnchorsAndBlocks(raw) {
+  if (typeof raw !== "string") return ""
+  return raw.split("#")[0].split("^")[0]
+}
+
+export function buildDocIndex(documents) {
+  const pathMap = new Map()
+  const titleMap = new Map()
+  const basenameMap = new Map()
+
+  for (const doc of documents) {
+    const lowerPath = doc.path.toLowerCase()
+    const pathWithoutExt = lowerPath.replace(/\.md$/i, "")
+    if (!pathMap.has(pathWithoutExt)) pathMap.set(pathWithoutExt, doc.id)
+    if (!pathMap.has(lowerPath)) pathMap.set(lowerPath, doc.id)
+
+    const lowerTitle = doc.title.toLowerCase()
+    pushUnique(titleMap, lowerTitle, doc.id)
+
+    const basename = doc.path.split("/").pop() ?? doc.title
+    const lowerBasename = basename.replace(/\.md$/i, "").toLowerCase()
+    pushUnique(basenameMap, lowerBasename, doc.id)
+  }
+
+  return { pathMap, titleMap, basenameMap }
+}
+
+function pushUnique(map, key, value) {
+  const existing = map.get(key)
+  if (!existing) {
+    map.set(key, [value])
+    return
+  }
+  if (!existing.includes(value)) existing.push(value)
+}
+
+export function resolveWikiTarget(rawTarget, docIndex, context = {}) {
+  if (!rawTarget) return null
+  const target = String(rawTarget).trim()
+  if (!target) return null
+
+  const lowerTarget = target.toLowerCase()
+  const normalizedPathTarget = lowerTarget.replace(/\.md$/i, "")
+
+  if (target.includes("/")) {
+    const hit = docIndex.pathMap.get(normalizedPathTarget) ?? docIndex.pathMap.get(lowerTarget)
+    if (hit) return hit
+  }
+
+  const titleHits = docIndex.titleMap.get(lowerTarget)
+  if (titleHits && titleHits.length > 0) {
+    return pickBestCandidate(titleHits, context, target)
+  }
+
+  const basenameHits = docIndex.basenameMap.get(normalizedPathTarget)
+  if (basenameHits && basenameHits.length > 0) {
+    return pickBestCandidate(basenameHits, context, target)
+  }
+
+  return null
+}
+
+function pickBestCandidate(candidates, context, target) {
+  if (candidates.length === 1) return candidates[0]
+
+  if (context?.sourceCategory && context?.catalog) {
+    const sameCategory = candidates.find((id) => {
+      const doc = context.catalog.get(id)
+      return doc && doc.category === context.sourceCategory
+    })
+    if (sameCategory) return sameCategory
+  }
+
+  if (context?.onAmbiguous) {
+    context.onAmbiguous(target, candidates)
+  }
+
+  return candidates[0]
+}

--- a/web/src/components/chat/answer-tool-ui.tsx
+++ b/web/src/components/chat/answer-tool-ui.tsx
@@ -1,6 +1,6 @@
+import type { ComponentProps } from "react"
 import Markdown from "react-markdown"
 import remarkGfm from "remark-gfm"
-import type { ComponentProps } from "react"
 import { sortSourcesBySection } from "@/lib/evidence-sort"
 import { cn } from "@/lib/utils"
 import { SourceCarousel } from "./source-carousel"
@@ -143,11 +143,7 @@ const answerMarkdownComponents = {
   ),
 }
 
-export function AnswerMessageContent({
-  answer,
-  sources,
-  className,
-}: AnswerMessageContentProps) {
+export function AnswerMessageContent({ answer, sources, className }: AnswerMessageContentProps) {
   const hasAnswer = answer.trim().length > 0
   if (!hasAnswer) return null
 

--- a/web/src/components/chat/source-carousel.tsx
+++ b/web/src/components/chat/source-carousel.tsx
@@ -1,5 +1,7 @@
-import { ChevronLeft, ChevronRight, FileSearch } from "lucide-react"
-import { useEffect, useRef, useState } from "react"
+import { ArrowLeft, ChevronLeft, ChevronRight, FileSearch } from "lucide-react"
+import { type ComponentProps, useEffect, useMemo, useRef, useState } from "react"
+import Markdown from "react-markdown"
+import remarkGfm from "remark-gfm"
 import { Button } from "@/components/ui/button"
 import { Carousel, CarouselContent, CarouselItem, useCarousel } from "@/components/ui/carousel"
 import {
@@ -15,6 +17,7 @@ import { dispatchChatPromptRequest } from "@/lib/chat-prompt"
 import { cn } from "@/lib/utils"
 import { SourceCard } from "./source-card"
 import type { Source } from "./types"
+import { extractWikiDocId, preprocessWikiLinks, type WikiLinkRef } from "./wiki-link-preprocessor"
 
 interface SourceCarouselProps {
   sources: Source[]
@@ -30,6 +33,8 @@ interface SourcePreviewResponse {
   summary: string
   excerpt: string
   tags: string[]
+  fullContent?: string
+  outLinks?: WikiLinkRef[]
 }
 
 function getActiveResumeVariant(): string {
@@ -72,6 +77,7 @@ export function SourceCarousel({ sources, className }: SourceCarouselProps) {
   const [previewError, setPreviewError] = useState<string | null>(null)
   const [isLoadingPreview, setIsLoadingPreview] = useState(false)
   const [selectedSourceId, setSelectedSourceId] = useState<string | null>(null)
+  const [navigationStack, setNavigationStack] = useState<string[]>([])
   const previewRequestIdRef = useRef(0)
   const previewAbortControllerRef = useRef<AbortController | null>(null)
 
@@ -83,28 +89,8 @@ export function SourceCarousel({ sources, className }: SourceCarouselProps) {
 
   if (sources.length === 0) return null
 
-  const handlePreviewOpenChange = (open: boolean) => {
-    setPreviewOpen(open)
-    if (open) return
-
-    previewAbortControllerRef.current?.abort()
-    previewAbortControllerRef.current = null
-    setIsLoadingPreview(false)
-    setSelectedSourceId(null)
-  }
-
-  const handleSourceClick = async (source: Source) => {
-    trackEvent("source_card_clicked", {
-      source_type: source.sourceType,
-      source_id: source.id,
-    })
-
-    if (!source.previewAvailable) return
-
-    setSelectedSourceId(source.id)
-    setPreview(null)
+  const fetchPreview = async (docId: string) => {
     setPreviewError(null)
-    setPreviewOpen(true)
     setIsLoadingPreview(true)
 
     const requestId = previewRequestIdRef.current + 1
@@ -116,7 +102,7 @@ export function SourceCarousel({ sources, className }: SourceCarouselProps) {
     try {
       const variant = getActiveResumeVariant()
       const response = await fetch(
-        `/api/source-preview?id=${encodeURIComponent(source.id)}&variant=${encodeURIComponent(variant)}`,
+        `/api/source-preview?id=${encodeURIComponent(docId)}&variant=${encodeURIComponent(variant)}&full=true`,
         { signal: abortController.signal }
       )
 
@@ -130,29 +116,91 @@ export function SourceCarousel({ sources, className }: SourceCarouselProps) {
       if (previewRequestIdRef.current !== requestId) return
 
       setPreview(data)
-      trackEvent("source_preview_opened", {
-        source_id: source.id,
-        source_type: source.sourceType,
-      })
+      return data
     } catch (error) {
-      if (error instanceof DOMException && error.name === "AbortError") {
-        return
-      }
+      if (error instanceof DOMException && error.name === "AbortError") return
       if (previewRequestIdRef.current !== requestId) return
 
       const message =
         error instanceof Error ? error.message : "출처 상세 정보를 불러오지 못했습니다."
       setPreviewError(message)
-      trackEvent("source_preview_failed", {
-        source_id: source.id,
-        source_type: source.sourceType,
-        error: message,
-      })
+      throw error
     } finally {
       if (previewRequestIdRef.current === requestId) {
         previewAbortControllerRef.current = null
         setIsLoadingPreview(false)
       }
+    }
+  }
+
+  const handlePreviewOpenChange = (open: boolean) => {
+    setPreviewOpen(open)
+    if (open) return
+
+    previewAbortControllerRef.current?.abort()
+    previewAbortControllerRef.current = null
+    setIsLoadingPreview(false)
+    setSelectedSourceId(null)
+    setNavigationStack([])
+  }
+
+  const handleSourceClick = async (source: Source) => {
+    trackEvent("source_card_clicked", {
+      source_type: source.sourceType,
+      source_id: source.id,
+    })
+
+    if (!source.previewAvailable) return
+
+    setSelectedSourceId(source.id)
+    setPreview(null)
+    setNavigationStack([])
+    setPreviewOpen(true)
+
+    try {
+      await fetchPreview(source.id)
+      trackEvent("source_preview_opened", {
+        source_id: source.id,
+        source_type: source.sourceType,
+      })
+    } catch (error) {
+      const message =
+        error instanceof Error ? error.message : "출처 상세 정보를 불러오지 못했습니다."
+      trackEvent("source_preview_failed", {
+        source_id: source.id,
+        source_type: source.sourceType,
+        error: message,
+      })
+    }
+  }
+
+  const handleWikiLinkNavigate = async (docId: string) => {
+    if (!preview || docId === preview.id) return
+    const previousId = preview.id
+
+    setNavigationStack((stack) => [...stack, previousId])
+    setPreview(null)
+    try {
+      await fetchPreview(docId)
+      trackEvent("source_preview_wiki_navigated", {
+        from_id: previousId,
+        to_id: docId,
+      })
+    } catch {
+      // 실패 시 스택 롤백하여 뒤로가기가 엉키지 않도록
+      setNavigationStack((stack) => stack.slice(0, -1))
+    }
+  }
+
+  const handlePreviewBack = async () => {
+    if (navigationStack.length === 0) return
+    const previousId = navigationStack[navigationStack.length - 1]
+    setNavigationStack((stack) => stack.slice(0, -1))
+    setPreview(null)
+    try {
+      await fetchPreview(previousId)
+    } catch {
+      // 유지: fetch 실패 시 스택은 이미 pop된 상태
     }
   }
 
@@ -208,47 +256,49 @@ export function SourceCarousel({ sources, className }: SourceCarouselProps) {
       </div>
 
       <Dialog open={previewOpen} onOpenChange={handlePreviewOpenChange}>
-        <DialogContent className="max-w-[calc(100%-2rem)] sm:max-w-xl">
-          <DialogHeader>
-            <DialogTitle>근거 상세 보기</DialogTitle>
-            <DialogDescription>답변 생성에 사용된 문서의 핵심 요약과 발췌입니다.</DialogDescription>
+        <DialogContent className="max-w-[calc(100%-2rem)] sm:max-w-2xl max-h-[85vh] flex flex-col gap-0 p-0">
+          <DialogHeader className="sticky top-0 z-10 border-b bg-background px-6 py-4">
+            <div className="flex items-center gap-2">
+              {navigationStack.length > 0 ? (
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  className="h-7 w-7 shrink-0"
+                  onClick={handlePreviewBack}
+                  disabled={isLoadingPreview}
+                  aria-label="이전 문서로 돌아가기"
+                >
+                  <ArrowLeft className="h-4 w-4" />
+                </Button>
+              ) : null}
+              <DialogTitle className="truncate text-left text-base">
+                {preview?.title ?? "근거 상세 보기"}
+              </DialogTitle>
+            </div>
+            <DialogDescription className="text-left text-xs text-muted-foreground">
+              {preview
+                ? `${preview.category} · ${preview.path}`
+                : "답변 생성에 사용된 Obsidian 문서의 전체 내용입니다."}
+            </DialogDescription>
           </DialogHeader>
 
-          {isLoadingPreview ? (
-            <p className="text-sm text-muted-foreground">근거 정보를 불러오는 중...</p>
-          ) : null}
+          <div className="overflow-y-auto px-6 py-4">
+            {isLoadingPreview ? (
+              <p className="text-sm text-muted-foreground">근거 정보를 불러오는 중...</p>
+            ) : null}
 
-          {previewError ? (
-            <p className="text-sm text-destructive" data-testid="source-preview-error">
-              {previewError}
-            </p>
-          ) : null}
+            {previewError ? (
+              <p className="text-sm text-destructive" data-testid="source-preview-error">
+                {previewError}
+              </p>
+            ) : null}
 
-          {preview ? (
-            <div className="space-y-3 text-sm" data-testid="source-preview-content">
-              <div>
-                <p className="font-medium text-foreground">{preview.title}</p>
-                <p className="text-xs text-muted-foreground">{preview.category}</p>
-              </div>
+            {preview && !isLoadingPreview ? (
+              <PreviewBody preview={preview} onWikiLinkNavigate={handleWikiLinkNavigate} />
+            ) : null}
+          </div>
 
-              <div className="rounded-md border bg-muted/20 p-3">
-                <p className="text-xs text-muted-foreground mb-1">요약</p>
-                <p className="leading-relaxed">{preview.summary}</p>
-              </div>
-
-              <div className="rounded-md border bg-muted/20 p-3">
-                <p className="text-xs text-muted-foreground mb-1">본문 발췌</p>
-                <p className="leading-relaxed">{preview.excerpt}</p>
-              </div>
-
-              <p className="text-xs text-muted-foreground">경로: {preview.path}</p>
-              {preview.tags.length > 0 ? (
-                <p className="text-xs text-muted-foreground">태그: {preview.tags.join(", ")}</p>
-              ) : null}
-            </div>
-          ) : null}
-
-          <DialogFooter>
+          <DialogFooter className="border-t bg-background px-6 py-3">
             <Button
               type="button"
               onClick={handleAskWithPreview}
@@ -262,4 +312,120 @@ export function SourceCarousel({ sources, className }: SourceCarouselProps) {
       </Dialog>
     </>
   )
+}
+
+interface PreviewBodyProps {
+  preview: SourcePreviewResponse
+  onWikiLinkNavigate: (docId: string) => void
+}
+
+function PreviewBody({ preview, onWikiLinkNavigate }: PreviewBodyProps) {
+  const outLinks = preview.outLinks ?? []
+  const processedMarkdown = useMemo(() => {
+    if (!preview.fullContent) return ""
+    return preprocessWikiLinks(preview.fullContent, outLinks)
+  }, [preview.fullContent, outLinks])
+
+  const components = useMemo(
+    () => createMarkdownComponents(onWikiLinkNavigate),
+    [onWikiLinkNavigate]
+  )
+
+  if (!processedMarkdown) {
+    return (
+      <div className="space-y-3 text-sm" data-testid="source-preview-content">
+        <div className="rounded-md border bg-muted/20 p-3">
+          <p className="mb-1 text-xs text-muted-foreground">요약</p>
+          <p className="leading-relaxed">{preview.summary}</p>
+        </div>
+        <div className="rounded-md border bg-muted/20 p-3">
+          <p className="mb-1 text-xs text-muted-foreground">본문 발췌</p>
+          <p className="leading-relaxed">{preview.excerpt}</p>
+        </div>
+        {preview.tags.length > 0 ? (
+          <p className="text-xs text-muted-foreground">태그: {preview.tags.join(", ")}</p>
+        ) : null}
+      </div>
+    )
+  }
+
+  return (
+    <div className="space-y-4 text-sm" data-testid="source-preview-content">
+      {preview.summary ? (
+        <div className="rounded-md border bg-muted/20 p-3">
+          <p className="mb-1 text-xs text-muted-foreground">요약</p>
+          <p className="leading-relaxed">{preview.summary}</p>
+        </div>
+      ) : null}
+
+      <div className="prose prose-sm max-w-none dark:prose-invert">
+        <Markdown remarkPlugins={[remarkGfm]} components={components}>
+          {processedMarkdown}
+        </Markdown>
+      </div>
+
+      {preview.tags.length > 0 ? (
+        <p className="text-xs text-muted-foreground">태그: {preview.tags.join(", ")}</p>
+      ) : null}
+    </div>
+  )
+}
+
+function createMarkdownComponents(onWikiLinkNavigate: (docId: string) => void) {
+  return {
+    a: ({ href, children, ...rest }: ComponentProps<"a">) => {
+      const wikiDocId = typeof href === "string" ? extractWikiDocId(href) : null
+      if (wikiDocId) {
+        return (
+          <button
+            type="button"
+            onClick={() => onWikiLinkNavigate(wikiDocId)}
+            className="text-primary underline underline-offset-2 hover:text-primary/80"
+            data-testid="source-preview-wiki-link"
+          >
+            {children}
+          </button>
+        )
+      }
+      return (
+        <a
+          href={href}
+          className="text-primary underline underline-offset-2 hover:text-primary/80"
+          target="_blank"
+          rel="noreferrer"
+          {...rest}
+        >
+          {children}
+        </a>
+      )
+    },
+    h1: ({ ...props }: ComponentProps<"h1">) => (
+      <h1 className="mt-4 mb-2 text-lg font-semibold" {...props} />
+    ),
+    h2: ({ ...props }: ComponentProps<"h2">) => (
+      <h2 className="mt-4 mb-2 text-base font-semibold" {...props} />
+    ),
+    h3: ({ ...props }: ComponentProps<"h3">) => (
+      <h3 className="mt-3 mb-1 text-sm font-semibold" {...props} />
+    ),
+    p: ({ ...props }: ComponentProps<"p">) => (
+      <p className="my-2 leading-relaxed first:mt-0 last:mb-0" {...props} />
+    ),
+    ul: ({ ...props }: ComponentProps<"ul">) => (
+      <ul className="my-2 ml-4 list-disc [&>li]:mt-1" {...props} />
+    ),
+    ol: ({ ...props }: ComponentProps<"ol">) => (
+      <ol className="my-2 ml-4 list-decimal [&>li]:mt-1" {...props} />
+    ),
+    li: ({ ...props }: ComponentProps<"li">) => <li className="leading-relaxed" {...props} />,
+    code: ({ ...props }: ComponentProps<"code">) => (
+      <code
+        className="rounded-md border border-border/50 bg-muted/50 px-1 py-0.5 font-mono text-[0.85em]"
+        {...props}
+      />
+    ),
+    blockquote: ({ ...props }: ComponentProps<"blockquote">) => (
+      <blockquote className="my-2 border-l-2 border-border pl-3 text-muted-foreground" {...props} />
+    ),
+  }
 }

--- a/web/src/components/chat/wiki-link-preprocessor.ts
+++ b/web/src/components/chat/wiki-link-preprocessor.ts
@@ -1,0 +1,69 @@
+/**
+ * Obsidian wiki 링크 전처리
+ * [[target]] / [[target|alias]] → 표준 마크다운 링크 `[alias](#wiki/{docId})`
+ * ![[image.png]] → 코드 텍스트 `📎 이미지: image.png`
+ * outLinks에 매칭되지 않는 wiki 링크는 일반 텍스트(alias || target)로 치환
+ */
+
+const WIKI_LINK_PATTERN = /(!?)\[\[([^[\]\n]+?)(?:\|([^[\]\n]+?))?\]\]/g
+const IMAGE_EXTENSION_PATTERN = /\.(png|jpe?g|gif|svg|webp|bmp|avif)$/i
+
+export const WIKI_LINK_HREF_PREFIX = "#wiki/"
+
+export interface WikiLinkRef {
+  id: string
+  title: string
+}
+
+function stripAnchorsAndBlocks(raw: string): string {
+  return raw.split("#")[0].split("^")[0]
+}
+
+export function preprocessWikiLinks(
+  markdown: string,
+  outLinks: readonly WikiLinkRef[] = []
+): string {
+  if (!markdown) return ""
+
+  const titleIndex = new Map<string, string>()
+  for (const link of outLinks) {
+    if (link?.title && link?.id) titleIndex.set(link.title.toLowerCase(), link.id)
+  }
+
+  return markdown.replace(WIKI_LINK_PATTERN, (_match, embed, rawTarget, alias) => {
+    const cleanedTarget = stripAnchorsAndBlocks(String(rawTarget ?? "")).trim()
+    if (!cleanedTarget) return ""
+
+    const display =
+      typeof alias === "string" && alias.trim().length > 0 ? alias.trim() : cleanedTarget
+
+    if (embed === "!") {
+      if (IMAGE_EXTENSION_PATTERN.test(cleanedTarget)) {
+        return `\`📎 이미지: ${cleanedTarget}\``
+      }
+      return display
+    }
+
+    const docId = titleIndex.get(cleanedTarget.toLowerCase())
+    if (!docId) return display
+
+    const safeDisplay = escapeMarkdownBrackets(display)
+    return `[${safeDisplay}](${WIKI_LINK_HREF_PREFIX}${encodeURIComponent(docId)})`
+  })
+}
+
+function escapeMarkdownBrackets(text: string): string {
+  return text.replace(/\[/g, "\\[").replace(/\]/g, "\\]")
+}
+
+export function extractWikiDocId(href: string): string | null {
+  if (typeof href !== "string") return null
+  if (!href.startsWith(WIKI_LINK_HREF_PREFIX)) return null
+  const encoded = href.slice(WIKI_LINK_HREF_PREFIX.length)
+  if (!encoded) return null
+  try {
+    return decodeURIComponent(encoded)
+  } catch {
+    return null
+  }
+}

--- a/web/src/content/skills/ai-agent.json
+++ b/web/src/content/skills/ai-agent.json
@@ -7,7 +7,14 @@
     },
     {
       "name": "AI Agent & Automation",
-      "items": ["MCP (Model Context Protocol)", "LangGraph.js", "Deep Agents SDK", "Langfuse", "OpenTelemetry", "GitLab API"]
+      "items": [
+        "MCP (Model Context Protocol)",
+        "LangGraph.js",
+        "Deep Agents SDK",
+        "Langfuse",
+        "OpenTelemetry",
+        "GitLab API"
+      ]
     },
     {
       "name": "Frameworks & Runtime",

--- a/web/src/content/skills/frontend.json
+++ b/web/src/content/skills/frontend.json
@@ -7,7 +7,16 @@
     },
     {
       "name": "Frameworks & Libraries",
-      "items": ["React", "Astro", "Zustand", "TanStack Table", "TanStack Query", "TanStack Virtual", "ECharts", "TanStack Router"]
+      "items": [
+        "React",
+        "Astro",
+        "Zustand",
+        "TanStack Table",
+        "TanStack Query",
+        "TanStack Virtual",
+        "ECharts",
+        "TanStack Router"
+      ]
     },
     {
       "name": "Testing",

--- a/web/src/lib/pdf/serialize-resume.ts
+++ b/web/src/lib/pdf/serialize-resume.ts
@@ -1,7 +1,9 @@
 import { resolveResumeContent } from "@/lib/resume/content"
 import type { SerializedResumeData } from "./types"
 
-export async function serializeResumeData(variantInput?: string | null): Promise<SerializedResumeData> {
+export async function serializeResumeData(
+  variantInput?: string | null
+): Promise<SerializedResumeData> {
   const resumeContent = await resolveResumeContent(variantInput)
   const { profile, experienceEntries, blogPosts, education, certificates, awards, skillsData } =
     resumeContent

--- a/web/src/lib/work-agent/index.ts
+++ b/web/src/lib/work-agent/index.ts
@@ -33,12 +33,14 @@ export {
   createSearchContext,
   extractDocumentId,
   extractDocumentIds,
+  extractRelatedDocumentIds,
   validateSources,
 } from "./source-tracker"
 // AI Tools
 export {
   answer,
   createAnswerTool,
+  findRelated,
   readDocument,
   searchDocuments as searchDocumentsTool,
   workAgentTools,
@@ -49,6 +51,8 @@ export {
   type LiveResumeFeedItem,
   type ObsidianDocument,
   type ObsidianDocumentContent,
+  type ObsidianLinkRef,
+  type RelatedObsidianDocument,
   type SearchContext,
   type SourceValidationResult,
   WorkAgentError,

--- a/web/src/lib/work-agent/link-graph.ts
+++ b/web/src/lib/work-agent/link-graph.ts
@@ -1,0 +1,74 @@
+/**
+ * Wiki 링크 그래프 BFS 순수 함수
+ * obsidian.server의 상태에 의존하지 않도록 graph를 외부에서 주입받음
+ */
+
+export interface LinkGraphNode {
+  outLinks: readonly string[]
+  inLinks: readonly string[]
+}
+
+export interface BfsRelatedResult {
+  id: string
+  relation: "outLink" | "inLink"
+  distance: 1 | 2
+}
+
+const MAX_RESULTS = 20
+
+export function bfsRelatedNodes(
+  rootId: string,
+  graph: ReadonlyMap<string, LinkGraphNode>,
+  depth: 1 | 2 = 1
+): BfsRelatedResult[] {
+  const root = graph.get(rootId)
+  if (!root) return []
+
+  const visited = new Map<string, { relation: "outLink" | "inLink"; distance: 1 | 2 }>()
+
+  const enqueue = (neighborId: string, relation: "outLink" | "inLink", distance: 1 | 2) => {
+    if (neighborId === rootId) return
+    const existing = visited.get(neighborId)
+    if (!existing) {
+      visited.set(neighborId, { relation, distance })
+      return
+    }
+    if (distance < existing.distance) {
+      visited.set(neighborId, { relation, distance })
+      return
+    }
+    if (
+      distance === existing.distance &&
+      existing.relation === "inLink" &&
+      relation === "outLink"
+    ) {
+      visited.set(neighborId, { relation, distance })
+    }
+  }
+
+  for (const id of root.outLinks) enqueue(id, "outLink", 1)
+  for (const id of root.inLinks) enqueue(id, "inLink", 1)
+
+  if (depth === 2) {
+    const firstHop = Array.from(visited.keys())
+    for (const firstId of firstHop) {
+      const node = graph.get(firstId)
+      if (!node) continue
+      for (const id of node.outLinks) enqueue(id, "outLink", 2)
+      for (const id of node.inLinks) enqueue(id, "inLink", 2)
+    }
+  }
+
+  const results: BfsRelatedResult[] = []
+  for (const [id, info] of visited) {
+    results.push({ id, relation: info.relation, distance: info.distance })
+  }
+
+  results.sort((a, b) => {
+    if (a.distance !== b.distance) return a.distance - b.distance
+    if (a.relation !== b.relation) return a.relation === "outLink" ? -1 : 1
+    return a.id.localeCompare(b.id)
+  })
+
+  return results.slice(0, MAX_RESULTS)
+}

--- a/web/src/lib/work-agent/obsidian.server.ts
+++ b/web/src/lib/work-agent/obsidian.server.ts
@@ -7,7 +7,14 @@
  */
 
 import MiniSearch from "minisearch"
-import type { LiveResumeFeedItem, ObsidianDocument } from "./types"
+import { bfsRelatedNodes, type LinkGraphNode } from "./link-graph"
+import { reciprocalRankFusion } from "./rrf"
+import type {
+  LiveResumeFeedItem,
+  ObsidianDocument,
+  ObsidianLinkRef,
+  RelatedObsidianDocument,
+} from "./types"
 
 interface VaultDocument {
   id: string
@@ -20,14 +27,20 @@ interface VaultDocument {
   eventDate?: string
   updatedAt?: string
   activityAt?: string
+  outLinks?: string[]
+  inLinks?: string[]
+  imageLinks?: string[]
 }
 
 interface VaultData {
   documents: VaultDocument[]
 }
 
+type EmbeddingsData = Record<string, number[]>
+
 const GENERATED_VAULT_DATA_KEY = "../../generated/vault-data.json"
 const GENERATED_SEARCH_INDEX_KEY = "../../generated/search-index.json"
+const GENERATED_EMBEDDINGS_KEY = "../../generated/vault-embeddings.json"
 const GENERATED_JSON_MODULES = import.meta.glob("../../generated/*.json", {
   eager: true,
   import: "default",
@@ -66,6 +79,12 @@ let _vaultData: VaultData | null = null
 
 // MiniSearch 인덱스 (레이지 초기화)
 let _searchIndex: MiniSearch | null = null
+
+// 임베딩 맵 (ID → unit-normalized vector)
+let _embeddingsMap: Map<string, number[]> | null = null
+
+// 문서 카탈로그 인덱스 (ID로 빠른 조회)
+let _catalogMap: Map<string, ObsidianDocument> | null = null
 
 const MINISEARCH_OPTIONS = {
   fields: ["title", "category", "tagsText", "summary", "content"],
@@ -128,13 +147,45 @@ function getSearchIndex(): MiniSearch {
 }
 
 function ensureLoaded(): void {
-  if (_catalog && _contentMap) return
+  if (_catalog && _contentMap && _catalogMap) return
 
   const data = getVaultData()
-  _catalog = data.documents.map(({ content: _, ...meta }) => meta)
+  _catalog = data.documents.map(({ content: _content, ...meta }) => ({
+    id: meta.id,
+    title: meta.title,
+    category: meta.category,
+    path: meta.path,
+    summary: meta.summary,
+    tags: meta.tags,
+    ...(meta.eventDate ? { eventDate: meta.eventDate } : {}),
+    ...(meta.updatedAt ? { updatedAt: meta.updatedAt } : {}),
+    ...(meta.activityAt ? { activityAt: meta.activityAt } : {}),
+  }))
   _contentMap = new Map(data.documents.map((doc) => [doc.id, doc]))
+  _catalogMap = new Map(_catalog.map((doc) => [doc.id, doc]))
 
   console.log(`[obsidian] Catalog loaded: ${_catalog.length} documents`)
+}
+
+function getEmbeddingsMap(): Map<string, number[]> {
+  if (_embeddingsMap) return _embeddingsMap
+
+  const loadedEmbeddings = readGeneratedModule<unknown>(GENERATED_EMBEDDINGS_KEY, "embeddings")
+  const map = new Map<string, number[]>()
+
+  if (!loadedEmbeddings || typeof loadedEmbeddings !== "object") {
+    _embeddingsMap = map
+    return map
+  }
+
+  for (const [id, vector] of Object.entries(loadedEmbeddings as EmbeddingsData)) {
+    if (Array.isArray(vector) && vector.length > 0) {
+      map.set(id, vector)
+    }
+  }
+
+  _embeddingsMap = map
+  return map
 }
 
 /**
@@ -152,6 +203,7 @@ export function resetCatalogCache(): void {
   _catalog = null
   _contentMap = null
   _vaultData = null
+  _catalogMap = null
 }
 
 /**
@@ -159,6 +211,13 @@ export function resetCatalogCache(): void {
  */
 export function resetSearchIndex(): void {
   _searchIndex = null
+}
+
+/**
+ * 임베딩 캐시 초기화 (테스트용)
+ */
+export function resetEmbeddingsCache(): void {
+  _embeddingsMap = null
 }
 
 /**
@@ -202,13 +261,155 @@ export function searchDocuments(query: string, limit = 20): ObsidianDocument[] {
 /**
  * 문서 ID로 전체 내용 읽기
  */
-export function readDocumentContent(
-  docId: string
-): (ObsidianDocument & { content: string }) | null {
+export function readDocumentContent(docId: string):
+  | (ObsidianDocument & {
+      content: string
+      outLinks: ObsidianLinkRef[]
+      inLinks: ObsidianLinkRef[]
+    })
+  | null {
   ensureLoaded()
   const doc = _contentMap?.get(docId)
   if (!doc) return null
-  return { ...doc }
+  return {
+    id: doc.id,
+    title: doc.title,
+    category: doc.category,
+    path: doc.path,
+    summary: doc.summary,
+    tags: doc.tags,
+    ...(doc.eventDate ? { eventDate: doc.eventDate } : {}),
+    ...(doc.updatedAt ? { updatedAt: doc.updatedAt } : {}),
+    ...(doc.activityAt ? { activityAt: doc.activityAt } : {}),
+    content: doc.content,
+    outLinks: toLinkRefs(doc.outLinks ?? []),
+    inLinks: toLinkRefs(doc.inLinks ?? []),
+  }
+}
+
+function toLinkRefs(ids: readonly string[]): ObsidianLinkRef[] {
+  ensureLoaded()
+  const map = _catalogMap
+  if (!map) return []
+  const refs: ObsidianLinkRef[] = []
+  for (const id of ids) {
+    const doc = map.get(id)
+    if (doc) refs.push({ id: doc.id, title: doc.title })
+  }
+  return refs
+}
+
+/**
+ * 벡터 유사도 기반 의미 검색
+ * 빌드 타임에 unit-normalize된 벡터 가정 → dot product만 수행
+ */
+export function semanticSearch(queryEmbedding: readonly number[], limit = 20): ObsidianDocument[] {
+  const safeLimit = Math.max(0, limit)
+  if (safeLimit === 0 || queryEmbedding.length === 0) return []
+
+  ensureLoaded()
+  const catalog = _catalog
+  const catalogMap = _catalogMap
+  if (!catalog || !catalogMap) return []
+
+  const embeddings = getEmbeddingsMap()
+  if (embeddings.size === 0) return []
+
+  const normalizedQuery = normalizeVector(queryEmbedding)
+
+  const scored: Array<{ doc: ObsidianDocument; score: number }> = []
+  for (const [docId, vector] of embeddings) {
+    if (vector.length !== normalizedQuery.length) continue
+    const doc = catalogMap.get(docId)
+    if (!doc) continue
+    let score = 0
+    for (let i = 0; i < vector.length; i++) score += vector[i] * normalizedQuery[i]
+    scored.push({ doc, score })
+  }
+
+  scored.sort((a, b) => b.score - a.score)
+  return scored.slice(0, safeLimit).map(({ doc }) => doc)
+}
+
+/**
+ * BM25 + 벡터 하이브리드 검색 (Reciprocal Rank Fusion)
+ */
+export function hybridSearch(
+  query: string,
+  queryEmbedding: readonly number[] | null,
+  limit = 20,
+  rrfK = 60
+): ObsidianDocument[] {
+  const bm25Results = searchDocuments(query, Math.max(limit, 30))
+
+  if (!queryEmbedding || queryEmbedding.length === 0) return bm25Results.slice(0, limit)
+
+  const vectorResults = semanticSearch(queryEmbedding, Math.max(limit, 30))
+  if (vectorResults.length === 0) return bm25Results.slice(0, limit)
+
+  return reciprocalRankFusion([bm25Results, vectorResults], rrfK, limit)
+}
+
+function normalizeVector(vector: readonly number[]): number[] {
+  let norm = 0
+  for (const value of vector) norm += value * value
+  norm = Math.sqrt(norm)
+  if (norm === 0) return vector.slice()
+  const normalized = new Array<number>(vector.length)
+  for (let i = 0; i < vector.length; i++) normalized[i] = vector[i] / norm
+  return normalized
+}
+
+/**
+ * 문서 ID와 연결된 outLinks / inLinks 조회
+ */
+export function getOutLinks(docId: string): ObsidianLinkRef[] {
+  ensureLoaded()
+  const doc = _contentMap?.get(docId)
+  return doc ? toLinkRefs(doc.outLinks ?? []) : []
+}
+
+export function getInLinks(docId: string): ObsidianLinkRef[] {
+  ensureLoaded()
+  const doc = _contentMap?.get(docId)
+  return doc ? toLinkRefs(doc.inLinks ?? []) : []
+}
+
+/**
+ * BFS로 링크 연결된 관련 문서 탐색
+ * depth=1: 직접 연결된 outLinks ∪ inLinks
+ * depth=2: 1단계 이웃에서 한 번 더 확장 (원본 제외, 중복은 짧은 distance 유지)
+ */
+export function findRelatedDocs(docId: string, depth: 1 | 2 = 1): RelatedObsidianDocument[] {
+  ensureLoaded()
+  const contentMap = _contentMap
+  const catalogMap = _catalogMap
+  if (!contentMap || !catalogMap || !contentMap.has(docId)) return []
+
+  const graph = new Map<string, LinkGraphNode>()
+  for (const [id, doc] of contentMap) {
+    graph.set(id, {
+      outLinks: doc.outLinks ?? [],
+      inLinks: doc.inLinks ?? [],
+    })
+  }
+
+  const bfsResults = bfsRelatedNodes(docId, graph, depth)
+  const results: RelatedObsidianDocument[] = []
+  for (const { id, relation, distance } of bfsResults) {
+    const doc = catalogMap.get(id)
+    if (!doc) continue
+    results.push({
+      id: doc.id,
+      title: doc.title,
+      category: doc.category,
+      path: doc.path,
+      relation,
+      distance,
+    })
+  }
+
+  return results
 }
 
 function toActivityTimestamp(activityAt: string | undefined): number | null {

--- a/web/src/lib/work-agent/prompts.ts
+++ b/web/src/lib/work-agent/prompts.ts
@@ -27,6 +27,8 @@ export interface StepAnalysis {
   lastToolName: string | null
   lastQueries: string[]
   totalSearchCount: number
+  findRelatedCount: number
+  hasCalledFindRelated: boolean
 }
 
 export interface DynamicPromptOptions {
@@ -177,12 +179,14 @@ export const INTENT_KEYWORDS: Record<UserIntent, string[]> = {
  */
 export const PERSONA_PROMPTS: Record<UserIntent, string> = {
   career_inquiry: `## 모드: 커리어 답변
-- 먼저 searchDocuments로 근거를 찾고, 필요한 문서는 readDocument로 확인하세요.
+- 구체적 프로젝트/회사 질문: searchDocuments → readDocument로 근거 확보.
+- 포괄적 질문(전체 경험, 역량, 강점 등): readDocument로 확인한 프로젝트 문서의 outLinks를 살피고 findRelated(depth=1)로 연관 기술 노트까지 탐색한 뒤 답변하세요.
 - 답변은 문제/해결/성과 순서로 간결하게 작성하세요.
 - 확인되지 않은 수치나 사실은 추측하지 마세요.`,
 
   technical_inquiry: `## 모드: 기술 답변
-- 기술 질문은 반드시 검색 근거를 확보한 뒤 답변하세요.
+- 구체적 기술 질문(특정 API, 구현 방법 등): searchDocuments → readDocument 순서로 근거 확보.
+- 추상적 주제(설계 철학, 아키텍처 원칙, 접근 방식, 코드 스타일 등): searchDocuments로 시드 문서 1~2개를 찾은 뒤 readDocument로 outLinks를 확인하고, findRelated(depth=1 또는 2)로 연관 문서를 연쇄 탐색하세요. 단편 정보만으로 철학/원칙을 단정하지 마세요.
 - 문서 제목만으로 단정하지 말고, 구현 세부는 readDocument로 검증하세요.
 - 설명은 기술 선택 이유와 구현 포인트 중심으로 작성하세요.`,
 
@@ -196,6 +200,14 @@ export const PERSONA_PROMPTS: Record<UserIntent, string> = {
 - 잡담은 간결하고 자연스럽게 응답하세요.
 - 근거가 없으면 추측하지 마세요.`,
 }
+
+/**
+ * 연쇄 탐색(findRelated 미사용) 힌트
+ */
+export const CHAIN_EXPLORATION_HINT = `## 연쇄 탐색 힌트
+- 이미 몇 차례 검색했지만 findRelated를 아직 호출하지 않았습니다.
+- readDocument 응답의 outLinks를 살펴보고, 관련 문서를 findRelated(depth=1)로 확장하세요.
+- 추상적 주제라면 2~3개 노트만으로 단정하지 말고 연결된 맥락을 먼저 파악하세요.`
 
 /**
  * 반복 호출 시 전략 전환 힌트(soft guidance)
@@ -304,6 +316,8 @@ export function analyzeToolCallPattern(
       lastToolName: null,
       lastQueries: [],
       totalSearchCount: 0,
+      findRelatedCount: 0,
+      hasCalledFindRelated: false,
     }
   }
 
@@ -329,14 +343,17 @@ export function analyzeToolCallPattern(
   }
 
   // 검색 도구 총 호출 횟수
-  const searchTools = ["searchDocuments", "readDocument"]
+  const searchTools = ["searchDocuments", "readDocument", "findRelated"]
   const totalSearchCount = history.filter((h) => searchTools.includes(h.toolName)).length
+  const findRelatedCount = history.filter((h) => h.toolName === "findRelated").length
 
   return {
     consecutiveSameToolCount: consecutiveCount,
     lastToolName,
     lastQueries,
     totalSearchCount,
+    findRelatedCount,
+    hasCalledFindRelated: findRelatedCount > 0,
   }
 }
 
@@ -374,6 +391,17 @@ ${options.analysis.lastQueries.map((q, i) => `${i + 1}. "${q}"`).join("\n")}
 
 위 쿼리와 다른 접근을 시도하세요.`)
       }
+    }
+
+    // 연쇄 탐색 힌트: 추상적 주제에서 searchDocuments만 반복하고 findRelated를 안 쓴 경우
+    const intentSupportsChaining =
+      options.intent === "technical_inquiry" || options.intent === "career_inquiry"
+    if (
+      intentSupportsChaining &&
+      options.analysis.totalSearchCount >= 2 &&
+      !options.analysis.hasCalledFindRelated
+    ) {
+      parts.push(CHAIN_EXPLORATION_HINT)
     }
   }
 

--- a/web/src/lib/work-agent/query-embedding.ts
+++ b/web/src/lib/work-agent/query-embedding.ts
@@ -1,0 +1,75 @@
+/**
+ * 쿼리 임베딩 모듈
+ * 런타임에 Vertex AI text-embedding-005로 쿼리 벡터화
+ * LRU 캐시로 동일 쿼리 반복 시 호출 절약
+ */
+
+import { createVertex } from "@ai-sdk/google-vertex"
+import type { EmbeddingModel } from "ai"
+import { embed } from "ai"
+
+const EMBEDDING_MODEL_ID = "text-embedding-005"
+const LRU_MAX_ENTRIES = 100
+const QUERY_CHAR_LIMIT = 4000
+
+const cache = new Map<string, number[]>()
+let cachedModel: EmbeddingModel | null = null
+
+export async function embedQuery(text: string): Promise<number[]> {
+  const normalized = text.trim()
+  if (!normalized) throw new Error("embedQuery: empty query")
+
+  const cacheKey =
+    normalized.length > QUERY_CHAR_LIMIT ? normalized.slice(0, QUERY_CHAR_LIMIT) : normalized
+
+  const cached = cache.get(cacheKey)
+  if (cached) {
+    cache.delete(cacheKey)
+    cache.set(cacheKey, cached)
+    return cached
+  }
+
+  const model = getEmbeddingModel()
+  const { embedding } = await embed({ model, value: cacheKey })
+
+  if (cache.size >= LRU_MAX_ENTRIES) {
+    const oldestKey = cache.keys().next().value
+    if (oldestKey !== undefined) cache.delete(oldestKey)
+  }
+  cache.set(cacheKey, embedding)
+
+  return embedding
+}
+
+function getEmbeddingModel(): EmbeddingModel {
+  if (cachedModel) return cachedModel
+
+  const privateKey = import.meta.env.FIREBASE_PRIVATE_KEY
+  const clientEmail = import.meta.env.FIREBASE_CLIENT_EMAIL
+  const projectId = import.meta.env.PUBLIC_FIREBASE_PROJECT_ID
+
+  if (!privateKey || !clientEmail || !projectId) {
+    throw new Error(
+      "embedQuery: missing FIREBASE_PRIVATE_KEY, FIREBASE_CLIENT_EMAIL, or PUBLIC_FIREBASE_PROJECT_ID"
+    )
+  }
+
+  const vertex = createVertex({
+    project: projectId,
+    location: "global",
+    googleAuthOptions: {
+      credentials: {
+        client_email: clientEmail,
+        private_key: privateKey.replace(/\\n/g, "\n"),
+      },
+    },
+  })
+
+  cachedModel = vertex.textEmbeddingModel(EMBEDDING_MODEL_ID)
+  return cachedModel
+}
+
+export function resetQueryEmbeddingCache(): void {
+  cache.clear()
+  cachedModel = null
+}

--- a/web/src/lib/work-agent/rrf.ts
+++ b/web/src/lib/work-agent/rrf.ts
@@ -1,0 +1,36 @@
+/**
+ * Reciprocal Rank Fusion (RRF)
+ * 여러 랭킹의 결과를 ID 기준으로 점수 합산하여 단일 리스트로 결합
+ * 공식: score(id) = Σ 1 / (k + rank_i(id))
+ */
+
+interface RankableItem {
+  id: string
+}
+
+export function reciprocalRankFusion<T extends RankableItem>(
+  rankings: readonly T[][],
+  k = 60,
+  limit = 20
+): T[] {
+  if (rankings.length === 0 || limit <= 0) return []
+
+  const scores = new Map<string, number>()
+  const firstSeen = new Map<string, T>()
+
+  for (const ranking of rankings) {
+    ranking.forEach((item, rank) => {
+      if (!item || typeof item.id !== "string") return
+      const current = scores.get(item.id) ?? 0
+      scores.set(item.id, current + 1 / (k + rank))
+      if (!firstSeen.has(item.id)) {
+        firstSeen.set(item.id, item)
+      }
+    })
+  }
+
+  return Array.from(scores.entries())
+    .sort(([, a], [, b]) => b - a)
+    .slice(0, limit)
+    .map(([id]) => firstSeen.get(id) as T)
+}

--- a/web/src/lib/work-agent/source-tracker.ts
+++ b/web/src/lib/work-agent/source-tracker.ts
@@ -32,6 +32,14 @@ interface ReadDocumentResult {
   }
 }
 
+// findRelated 결과 타입
+interface FindRelatedResult {
+  success: true
+  data: {
+    documents: Array<{ id: string }>
+  }
+}
+
 /**
  * 빈 SearchContext 생성
  */
@@ -63,6 +71,18 @@ export function extractDocumentId(result: unknown): string | null {
 }
 
 /**
+ * findRelated 결과에서 ID 목록 추출
+ */
+export function extractRelatedDocumentIds(result: unknown): string[] {
+  if (!result || typeof result !== "object") return []
+  const typedResult = result as { success?: boolean; data?: FindRelatedResult["data"] }
+  if (!typedResult.success || !typedResult.data?.documents) return []
+  return typedResult.data.documents
+    .map((doc) => doc?.id)
+    .filter((id): id is string => typeof id === "string" && id.length > 0)
+}
+
+/**
  * 전체 steps에서 SearchContext 구축
  */
 export function buildSearchContextFromSteps(steps: StepLike[]): SearchContext {
@@ -81,6 +101,11 @@ export function buildSearchContextFromSteps(steps: StepLike[]): SearchContext {
         case "readDocument": {
           const id = extractDocumentId(toolResult.result)
           if (id) context.obsidianDocIds.add(id)
+          break
+        }
+        case "findRelated": {
+          const ids = extractRelatedDocumentIds(toolResult.result)
+          for (const id of ids) context.obsidianDocIds.add(id)
           break
         }
       }

--- a/web/src/lib/work-agent/tools.ts
+++ b/web/src/lib/work-agent/tools.ts
@@ -78,9 +78,12 @@ export const readDocumentSchema = z.object({
 export const findRelatedSchema = z.object({
   documentId: z.string().describe("기준 문서 ID"),
   depth: z
-    .union([z.literal(1), z.literal(2)])
+    .number()
+    .int()
+    .min(1)
+    .max(2)
     .optional()
-    .describe("탐색 깊이 (기본 1). 2는 이웃의 이웃까지 포함."),
+    .describe("탐색 깊이 (1 또는 2, 기본 1). 2는 이웃의 이웃까지 포함."),
 })
 
 export const answerSchema = z.object({
@@ -199,7 +202,7 @@ export const findRelated = tool({
   inputSchema: findRelatedSchema,
   execute: async (params: FindRelatedInput) => {
     try {
-      const depth = params.depth ?? 1
+      const depth = params.depth === 2 ? 2 : 1
       const related: RelatedObsidianDocument[] = findRelatedDocs(params.documentId, depth)
 
       return {

--- a/web/src/lib/work-agent/tools.ts
+++ b/web/src/lib/work-agent/tools.ts
@@ -5,9 +5,20 @@
 
 import { tool } from "ai"
 import { z } from "zod"
-import { readDocumentContent, searchDocuments as searchDocumentsLocal } from "./obsidian.server"
+import {
+  findRelatedDocs,
+  hybridSearch,
+  readDocumentContent,
+  searchDocuments as searchDocumentsLocal,
+} from "./obsidian.server"
+import { embedQuery } from "./query-embedding"
 import { validateSources } from "./source-tracker"
-import type { ObsidianDocument, SearchContext, WorkAgentErrorCode } from "./types"
+import type {
+  ObsidianDocument,
+  RelatedObsidianDocument,
+  SearchContext,
+  WorkAgentErrorCode,
+} from "./types"
 import { WorkAgentError } from "./types"
 
 // 에러 응답 타입
@@ -56,12 +67,20 @@ function createErrorResponse(error: unknown): ToolErrorResponse {
 
 // 스키마 정의 (테스트용 export)
 export const searchDocumentsSchema = z.object({
-  query: z.string().describe("검색할 키워드 (한글 또는 영문)"),
+  query: z.string().describe("검색할 키워드 (한글 또는 영문). 자연어 문장도 가능합니다."),
   limit: z.number().min(1).max(50).optional().describe("반환할 최대 문서 수 (기본값: 20)"),
 })
 
 export const readDocumentSchema = z.object({
   documentId: z.string().describe("조회할 문서 ID"),
+})
+
+export const findRelatedSchema = z.object({
+  documentId: z.string().describe("기준 문서 ID"),
+  depth: z
+    .union([z.literal(1), z.literal(2)])
+    .optional()
+    .describe("탐색 깊이 (기본 1). 2는 이웃의 이웃까지 포함."),
 })
 
 export const answerSchema = z.object({
@@ -81,18 +100,35 @@ export const answerSchema = z.object({
 // Type definitions for inferred schemas
 type SearchDocumentsInput = z.infer<typeof searchDocumentsSchema>
 type ReadDocumentInput = z.infer<typeof readDocumentSchema>
+type FindRelatedInput = z.infer<typeof findRelatedSchema>
 
 /**
  * 문서 검색 도구
- * Obsidian 볼트에서 키워드로 문서 검색
+ * Obsidian 볼트에서 키워드/의미 기반 하이브리드 검색
+ * - BM25(MiniSearch): 고유명사/정확 매칭에 강함
+ * - 벡터(text-embedding-005): 추상적 개념/자연어 질의에 강함
+ * - 임베딩 호출 실패 시 BM25로 자동 fallback
  */
 export const searchDocuments = tool({
   description:
-    "Obsidian 볼트에서 문서를 검색합니다. 제목, 카테고리, 태그, 요약, 본문에서 풀텍스트 검색합니다.",
+    "Obsidian 볼트에서 문서를 검색합니다. 키워드와 의미(임베딩)를 결합한 하이브리드 검색으로 추상적 질문과 고유명사 질문 모두에 대응합니다.",
   inputSchema: searchDocumentsSchema,
   execute: async (params: SearchDocumentsInput) => {
     try {
-      const results = searchDocumentsLocal(params.query, params.limit ?? 20)
+      const limit = params.limit ?? 20
+      let queryEmbedding: number[] | null = null
+      try {
+        queryEmbedding = await embedQuery(params.query)
+      } catch (error) {
+        console.warn(
+          "[searchDocuments] Query embedding failed, falling back to BM25:",
+          error instanceof Error ? error.message : error
+        )
+      }
+
+      const results = queryEmbedding
+        ? hybridSearch(params.query, queryEmbedding, limit)
+        : searchDocumentsLocal(params.query, limit)
 
       const documents: ObsidianDocument[] = results.map((doc) => ({
         id: doc.id,
@@ -118,11 +154,11 @@ export const searchDocuments = tool({
 
 /**
  * 문서 상세 조회 도구
- * 특정 문서의 전체 내용을 가져옴
+ * 특정 문서의 전체 내용 + 이 문서가 참조하는 관련 문서(outLinks) 반환
  */
 export const readDocument = tool({
   description:
-    "Obsidian 볼트 문서의 전체 내용을 조회합니다. searchDocuments로 찾은 문서의 상세 내용을 확인할 때 사용합니다.",
+    "Obsidian 볼트 문서의 전체 내용을 조회합니다. 응답에는 본문과 이 문서가 [[wiki 링크]]로 참조하는 관련 문서 목록(outLinks)이 포함됩니다. 추상적 주제를 탐색할 땐 outLinks를 보고 findRelated로 확장하세요.",
   inputSchema: readDocumentSchema,
   execute: async (params: ReadDocumentInput) => {
     try {
@@ -144,6 +180,33 @@ export const readDocument = tool({
             path: result.path,
           },
           content: result.content,
+          outLinks: result.outLinks,
+        },
+      }
+    } catch (error) {
+      return createErrorResponse(error)
+    }
+  },
+})
+
+/**
+ * 관련 문서 탐색 도구
+ * wiki 링크 그래프(outLinks ∪ inLinks)를 따라 depth만큼 연결된 문서를 반환
+ */
+export const findRelated = tool({
+  description:
+    "특정 문서와 [[wiki 링크]]로 연결된 관련 문서들을 찾습니다. 추상적 주제(아키텍처 철학, 설계 원칙, 접근 방식 등)를 연쇄 탐색할 때 사용하세요. depth=1은 직접 연결, depth=2는 이웃의 이웃까지 확장합니다.",
+  inputSchema: findRelatedSchema,
+  execute: async (params: FindRelatedInput) => {
+    try {
+      const depth = params.depth ?? 1
+      const related: RelatedObsidianDocument[] = findRelatedDocs(params.documentId, depth)
+
+      return {
+        success: true as const,
+        data: {
+          documents: related,
+          totalFound: related.length,
         },
       }
     } catch (error) {
@@ -202,5 +265,6 @@ export function createAnswerTool(getSearchContext: () => SearchContext) {
 export const workAgentTools = {
   searchDocuments,
   readDocument,
+  findRelated,
   answer,
 }

--- a/web/src/lib/work-agent/types.ts
+++ b/web/src/lib/work-agent/types.ts
@@ -39,6 +39,19 @@ export interface ObsidianDocument {
 export interface ObsidianDocumentContent {
   document: ObsidianDocument
   content: string
+  outLinks: ObsidianLinkRef[]
+}
+
+export interface ObsidianLinkRef {
+  id: string
+  title: string
+}
+
+export interface RelatedObsidianDocument extends ObsidianLinkRef {
+  category: string
+  path: string
+  relation: "outLink" | "inLink"
+  distance: 1 | 2
 }
 
 export interface LiveResumeFeedItem {

--- a/web/src/pages/api/chat.ts
+++ b/web/src/pages/api/chat.ts
@@ -10,8 +10,8 @@ import {
   stepCountIs,
   streamText,
 } from "ai"
-import { buildResumePrompt } from "@/lib/resume-prompt"
 import { parseResumeVariant, type ResumeVariantId } from "@/lib/resume/variant"
+import { buildResumePrompt } from "@/lib/resume-prompt"
 import { createToolInputDeltaFilter } from "@/lib/stream/filter-tool-input-delta"
 import {
   analyzeToolCallPattern,
@@ -28,8 +28,12 @@ import { buildCatalogSummary } from "@/lib/work-agent/obsidian.server"
 import { WorkAgentError } from "@/lib/work-agent/types"
 
 type ToolName = keyof typeof workAgentTools
-const SEARCH_TOOLS: ToolName[] = ["searchDocuments", "readDocument"]
+const SEARCH_TOOLS: ToolName[] = ["searchDocuments", "readDocument", "findRelated"]
 const ALL_TOOLS: ToolName[] = [...SEARCH_TOOLS, "answer"]
+
+function resolveEarlyForceStep(intent: ReturnType<typeof classifyIntent>["intent"]): number {
+  return intent === "technical_inquiry" || intent === "career_inquiry" ? 6 : 3
+}
 
 const SYSTEM_PROMPT_HEADER = `당신은 최기환의 이력서 웹사이트에서 방문자의 질문에 답변하는 AI 어시스턴트입니다.
 
@@ -163,8 +167,11 @@ export const POST = async ({ request }: { request: Request }) => {
     const tools = {
       searchDocuments: workAgentTools.searchDocuments,
       readDocument: workAgentTools.readDocument,
+      findRelated: workAgentTools.findRelated,
       answer: dynamicAnswerTool,
     }
+
+    const earlyForceStep = resolveEarlyForceStep(intentClassification.intent)
 
     const result = streamText({
       model: vertex("gemini-3.1-pro-preview"),
@@ -220,7 +227,18 @@ export const POST = async ({ request }: { request: Request }) => {
         }
 
         const answered = hasAnswerToolCall(steps)
-        if (!answered && stepNumber >= 2) {
+
+        // 동일 도구 5회 이상 연속 호출 → 무한 루프 방어: answer 강제
+        if (!answered && analysis.consecutiveSameToolCount >= 5) {
+          return {
+            system: stepSystemPrompt,
+            activeTools: ["answer"],
+            toolChoice: "required" as const,
+          }
+        }
+
+        // 의도별 강제 answer step (연쇄 탐색 허용)
+        if (!answered && stepNumber >= earlyForceStep) {
           return {
             system: stepSystemPrompt,
             activeTools: ["answer"],
@@ -236,7 +254,7 @@ export const POST = async ({ request }: { request: Request }) => {
         }
       },
 
-      stopWhen: [stepCountIs(15), hasToolCall("answer")],
+      stopWhen: [stepCountIs(20), hasToolCall("answer")],
 
       onStepFinish: ({ toolCalls, toolResults, finishReason, usage }) => {
         if (toolCalls.length > 0) {

--- a/web/src/pages/api/source-preview.ts
+++ b/web/src/pages/api/source-preview.ts
@@ -82,6 +82,7 @@ export function buildExcerpt(content: string, summary: string): string {
 export const GET = async ({ request }: { request: Request }) => {
   const url = new URL(request.url)
   const id = url.searchParams.get("id")?.trim()
+  const wantFullContent = url.searchParams.get("full") === "true"
   parseResumeVariant(url.searchParams.get("variant"))
 
   if (!id) {
@@ -102,20 +103,24 @@ export const GET = async ({ request }: { request: Request }) => {
   const summary = document.summary?.trim() || "요약 정보가 없습니다."
   const excerpt = buildExcerpt(document.content, summary)
 
-  return new Response(
-    JSON.stringify({
-      id: document.id,
-      sourceType: "obsidian",
-      title: document.title,
-      category: document.category,
-      path: document.path,
-      summary,
-      excerpt,
-      tags: document.tags,
-    }),
-    {
-      status: 200,
-      headers: { "Content-Type": "application/json" },
-    }
-  )
+  const payload: Record<string, unknown> = {
+    id: document.id,
+    sourceType: "obsidian",
+    title: document.title,
+    category: document.category,
+    path: document.path,
+    summary,
+    excerpt,
+    tags: document.tags,
+  }
+
+  if (wantFullContent) {
+    payload.fullContent = stripFrontmatter(document.content).trimStart()
+    payload.outLinks = document.outLinks
+  }
+
+  return new Response(JSON.stringify(payload), {
+    status: 200,
+    headers: { "Content-Type": "application/json" },
+  })
 }

--- a/web/tests/components/chat/wiki-link-preprocessor.test.ts
+++ b/web/tests/components/chat/wiki-link-preprocessor.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from "vitest"
+import {
+  extractWikiDocId,
+  preprocessWikiLinks,
+  WIKI_LINK_HREF_PREFIX,
+} from "../../../src/components/chat/wiki-link-preprocessor"
+
+describe("preprocessWikiLinks", () => {
+  it("outLinks에 매칭되는 [[target]]은 마크다운 링크로 변환", () => {
+    const markdown = "이건 [[TLS 협상]] 참조."
+    const result = preprocessWikiLinks(markdown, [{ id: "Network--TLS", title: "TLS 협상" }])
+    expect(result).toBe(`이건 [TLS 협상](${WIKI_LINK_HREF_PREFIX}Network--TLS) 참조.`)
+  })
+
+  it("alias가 있으면 alias를 링크 텍스트로 사용", () => {
+    const markdown = "[[TLS 협상|암호화 과정]]"
+    const result = preprocessWikiLinks(markdown, [{ id: "Network--TLS", title: "TLS 협상" }])
+    expect(result).toBe(`[암호화 과정](${WIKI_LINK_HREF_PREFIX}Network--TLS)`)
+  })
+
+  it("outLinks에 매칭되지 않으면 일반 텍스트로 치환", () => {
+    const markdown = "[[알 수 없는 문서]]"
+    const result = preprocessWikiLinks(markdown, [])
+    expect(result).toBe("알 수 없는 문서")
+  })
+
+  it("매칭되지 않고 alias가 있으면 alias를 텍스트로", () => {
+    const markdown = "[[not-found|대체 이름]]"
+    const result = preprocessWikiLinks(markdown, [])
+    expect(result).toBe("대체 이름")
+  })
+
+  it("이미지 임베드는 📎 이미지 텍스트로 치환", () => {
+    const markdown = "![[Pasted image.png]]"
+    const result = preprocessWikiLinks(markdown, [])
+    expect(result).toBe("`📎 이미지: Pasted image.png`")
+  })
+
+  it("이미지가 아닌 임베드는 display로 치환", () => {
+    const markdown = "![[일반 노트]]"
+    const result = preprocessWikiLinks(markdown, [])
+    expect(result).toBe("일반 노트")
+  })
+
+  it("대소문자 무시 매칭", () => {
+    const result = preprocessWikiLinks("[[tls 협상]]", [{ id: "Network--TLS", title: "TLS 협상" }])
+    expect(result).toBe(`[tls 협상](${WIKI_LINK_HREF_PREFIX}Network--TLS)`)
+  })
+
+  it("빈 마크다운 안전 처리", () => {
+    expect(preprocessWikiLinks("", [])).toBe("")
+  })
+
+  it("여러 링크 동시 처리", () => {
+    const markdown = "먼저 [[A]], 그 다음 [[B|비]]."
+    const result = preprocessWikiLinks(markdown, [
+      { id: "doc-a", title: "A" },
+      { id: "doc-b", title: "B" },
+    ])
+    expect(result).toBe(
+      `먼저 [A](${WIKI_LINK_HREF_PREFIX}doc-a), 그 다음 [비](${WIKI_LINK_HREF_PREFIX}doc-b).`
+    )
+  })
+})
+
+describe("extractWikiDocId", () => {
+  it("wiki href에서 id 추출", () => {
+    expect(extractWikiDocId(`${WIKI_LINK_HREF_PREFIX}doc-abc`)).toBe("doc-abc")
+  })
+
+  it("URL 인코딩된 id 복원", () => {
+    const encoded = encodeURIComponent("React.js--use Ref")
+    expect(extractWikiDocId(`${WIKI_LINK_HREF_PREFIX}${encoded}`)).toBe("React.js--use Ref")
+  })
+
+  it("wiki 프리픽스가 아니면 null", () => {
+    expect(extractWikiDocId("https://example.com")).toBeNull()
+    expect(extractWikiDocId("#hash")).toBeNull()
+  })
+
+  it("빈/잘못된 입력에서 null", () => {
+    expect(extractWikiDocId("")).toBeNull()
+    expect(extractWikiDocId(WIKI_LINK_HREF_PREFIX)).toBeNull()
+    expect(extractWikiDocId(undefined as unknown as string)).toBeNull()
+  })
+})

--- a/web/tests/components/source-carousel.test.tsx
+++ b/web/tests/components/source-carousel.test.tsx
@@ -138,7 +138,7 @@ describe("SourceCarousel", () => {
     )
 
     await waitFor(() => {
-      expect(screen.getByTestId("source-preview-content").textContent).toContain("두 번째 문서")
+      expect(screen.getByRole("dialog").textContent).toContain("두 번째 문서")
     })
 
     firstResponse.resolve(
@@ -158,9 +158,9 @@ describe("SourceCarousel", () => {
     )
 
     await waitFor(() => {
-      const previewText = screen.getByTestId("source-preview-content").textContent ?? ""
-      expect(previewText).toContain("두 번째 문서")
-      expect(previewText).not.toContain("첫 번째 문서")
+      const dialogText = screen.getByRole("dialog").textContent ?? ""
+      expect(dialogText).toContain("두 번째 문서")
+      expect(dialogText).not.toContain("첫 번째 문서")
     })
   })
 })

--- a/web/tests/lib/resume/variant.test.ts
+++ b/web/tests/lib/resume/variant.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "vitest"
-import { isResumeRoutePath, parseResumeVariant, parseResumeVariantFromPath } from "@/lib/resume/variant"
+import {
+  isResumeRoutePath,
+  parseResumeVariant,
+  parseResumeVariantFromPath,
+} from "@/lib/resume/variant"
 
 describe("resume variant route smoke", () => {
   it("/와 /ai-agent를 resume route로 인식한다", () => {

--- a/web/tests/lib/work-agent/link-graph.test.ts
+++ b/web/tests/lib/work-agent/link-graph.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, it } from "vitest"
+import { bfsRelatedNodes, type LinkGraphNode } from "../../../src/lib/work-agent/link-graph"
+
+function makeGraph(
+  entries: Record<string, { out?: string[]; in?: string[] }>
+): Map<string, LinkGraphNode> {
+  const graph = new Map<string, LinkGraphNode>()
+  for (const [id, links] of Object.entries(entries)) {
+    graph.set(id, { outLinks: links.out ?? [], inLinks: links.in ?? [] })
+  }
+  return graph
+}
+
+describe("bfsRelatedNodes", () => {
+  it("depth=1: outLinks와 inLinks 모두 포함하고 자기 자신 제외", () => {
+    const graph = makeGraph({
+      root: { out: ["a", "b"], in: ["c"] },
+      a: {},
+      b: {},
+      c: {},
+    })
+
+    const result = bfsRelatedNodes("root", graph, 1)
+    const ids = result.map((r) => r.id)
+    expect(ids).toContain("a")
+    expect(ids).toContain("b")
+    expect(ids).toContain("c")
+    expect(ids).not.toContain("root")
+
+    // outLink가 inLink보다 앞에 와야 함 (same distance)
+    const aRelation = result.find((r) => r.id === "a")
+    const cRelation = result.find((r) => r.id === "c")
+    expect(aRelation?.relation).toBe("outLink")
+    expect(cRelation?.relation).toBe("inLink")
+  })
+
+  it("depth=2: 이웃의 이웃도 포함, 거리 짧은 쪽 유지", () => {
+    const graph = makeGraph({
+      root: { out: ["a"] },
+      a: { out: ["b"] },
+      b: { out: ["c"] },
+    })
+
+    const result = bfsRelatedNodes("root", graph, 2)
+    const distances = new Map(result.map((r) => [r.id, r.distance]))
+    expect(distances.get("a")).toBe(1)
+    expect(distances.get("b")).toBe(2)
+    // c는 3-hop이므로 포함되지 않음
+    expect(distances.has("c")).toBe(false)
+  })
+
+  it("순환 그래프(A→B→A)에서도 자기 자신 제외", () => {
+    const graph = makeGraph({
+      root: { out: ["b"] },
+      b: { out: ["root"] },
+    })
+
+    const result = bfsRelatedNodes("root", graph, 2)
+    const ids = result.map((r) => r.id)
+    expect(ids).toEqual(["b"])
+  })
+
+  it("동일 거리에서 outLink가 inLink를 덮어씀 (symmetric case)", () => {
+    // root -out→ a, a -in← root (inLinks 기준), 같은 distance 1에서 outLink 우선
+    const graph = makeGraph({
+      root: { out: ["a"], in: ["a"] },
+      a: {},
+    })
+
+    const result = bfsRelatedNodes("root", graph, 1)
+    expect(result).toHaveLength(1)
+    expect(result[0].id).toBe("a")
+    expect(result[0].relation).toBe("outLink")
+  })
+
+  it("graph에 root가 없으면 빈 결과", () => {
+    const graph = makeGraph({ other: { out: ["x"] } })
+    expect(bfsRelatedNodes("missing", graph, 1)).toEqual([])
+  })
+
+  it("MAX_RESULTS(20) 초과 시 상위 20개만 반환", () => {
+    const entries: Record<string, { out?: string[] }> = { root: { out: [] } }
+    for (let i = 0; i < 30; i++) {
+      entries[`n${i}`] = {}
+    }
+    entries.root.out = Object.keys(entries).filter((k) => k !== "root")
+    const graph = makeGraph(entries)
+
+    const result = bfsRelatedNodes("root", graph, 1)
+    expect(result).toHaveLength(20)
+  })
+
+  it("결과 정렬: distance → relation(outLink 우선) → id", () => {
+    const graph = makeGraph({
+      root: { out: ["z", "a"], in: ["m"] },
+      z: {},
+      a: {},
+      m: {},
+    })
+
+    const result = bfsRelatedNodes("root", graph, 1)
+    // 같은 distance: outLink먼저 → id 오름차순
+    expect(result.map((r) => r.id)).toEqual(["a", "z", "m"])
+  })
+})

--- a/web/tests/lib/work-agent/prompts.test.ts
+++ b/web/tests/lib/work-agent/prompts.test.ts
@@ -198,6 +198,8 @@ describe("prompts", () => {
         lastToolName: "searchDocuments",
         lastQueries: ["query1", "query2", "query3"],
         totalSearchCount: 3,
+        findRelatedCount: 0,
+        hasCalledFindRelated: false,
       }
       const result = buildDynamicSystemPrompt({
         intent: "career_inquiry",
@@ -218,6 +220,8 @@ describe("prompts", () => {
         lastToolName: "searchDocuments",
         lastQueries: ["query1", "query2"],
         totalSearchCount: 2,
+        findRelatedCount: 0,
+        hasCalledFindRelated: false,
       }
       const result = buildDynamicSystemPrompt({
         intent: "career_inquiry",
@@ -233,6 +237,8 @@ describe("prompts", () => {
         lastToolName: "searchDocuments",
         lastQueries: ["q1", "q2", "q3", "q4", "q5"],
         totalSearchCount: 5,
+        findRelatedCount: 0,
+        hasCalledFindRelated: false,
       }
       const result = buildDynamicSystemPrompt({
         intent: "career_inquiry",
@@ -240,6 +246,40 @@ describe("prompts", () => {
         includeReflexion: false,
       })
       expect(result).not.toContain("전략 전환 힌트")
+    })
+
+    it("technical_inquiry에서 검색 2회 이상 + findRelated 미사용 시 연쇄 탐색 힌트 추가", () => {
+      const analysis = {
+        consecutiveSameToolCount: 1,
+        lastToolName: "searchDocuments",
+        lastQueries: ["x"],
+        totalSearchCount: 2,
+        findRelatedCount: 0,
+        hasCalledFindRelated: false,
+      }
+      const result = buildDynamicSystemPrompt({
+        intent: "technical_inquiry",
+        analysis,
+        includeReflexion: true,
+      })
+      expect(result).toContain("연쇄 탐색 힌트")
+    })
+
+    it("findRelated를 이미 호출했다면 연쇄 탐색 힌트 미포함", () => {
+      const analysis = {
+        consecutiveSameToolCount: 1,
+        lastToolName: "findRelated",
+        lastQueries: [],
+        totalSearchCount: 3,
+        findRelatedCount: 1,
+        hasCalledFindRelated: true,
+      }
+      const result = buildDynamicSystemPrompt({
+        intent: "technical_inquiry",
+        analysis,
+        includeReflexion: true,
+      })
+      expect(result).not.toContain("연쇄 탐색 힌트")
     })
   })
 

--- a/web/tests/lib/work-agent/rrf.test.ts
+++ b/web/tests/lib/work-agent/rrf.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from "vitest"
+import { reciprocalRankFusion } from "../../../src/lib/work-agent/rrf"
+
+interface Item {
+  id: string
+  label?: string
+}
+
+describe("reciprocalRankFusion", () => {
+  it("빈 입력에서 빈 배열 반환", () => {
+    expect(reciprocalRankFusion<Item>([])).toEqual([])
+    expect(reciprocalRankFusion<Item>([[]], 60, 10)).toEqual([])
+  })
+
+  it("단일 랭킹이면 순서 보존", () => {
+    const ranking: Item[] = [{ id: "a" }, { id: "b" }, { id: "c" }]
+    const result = reciprocalRankFusion([ranking])
+    expect(result.map((r) => r.id)).toEqual(["a", "b", "c"])
+  })
+
+  it("두 랭킹 모두에 있는 문서가 상위로 올라감", () => {
+    const bm25: Item[] = [{ id: "x", label: "from-bm25" }, { id: "a" }, { id: "b" }]
+    const vector: Item[] = [{ id: "y" }, { id: "x", label: "from-vector" }, { id: "b" }]
+
+    const result = reciprocalRankFusion([bm25, vector], 60, 5)
+
+    // x는 두 랭킹 모두 상위 → 1위
+    expect(result[0].id).toBe("x")
+    // 첫 등장 메타 보존 (bm25 먼저)
+    expect(result[0].label).toBe("from-bm25")
+  })
+
+  it("겹치지 않는 결과는 각 랭킹 상위가 번갈아 나옴", () => {
+    const bm25: Item[] = [{ id: "a" }, { id: "b" }]
+    const vector: Item[] = [{ id: "c" }, { id: "d" }]
+
+    const result = reciprocalRankFusion([bm25, vector], 60, 4)
+
+    // a와 c는 같은 점수 1/(60+0), b와 d는 1/(60+1)
+    const topTwoIds = result
+      .slice(0, 2)
+      .map((r) => r.id)
+      .sort()
+    expect(topTwoIds).toEqual(["a", "c"])
+
+    const lastTwoIds = result
+      .slice(2, 4)
+      .map((r) => r.id)
+      .sort()
+    expect(lastTwoIds).toEqual(["b", "d"])
+  })
+
+  it("limit 파라미터 준수", () => {
+    const ranking: Item[] = Array.from({ length: 10 }, (_, i) => ({ id: `d${i}` }))
+    const result = reciprocalRankFusion([ranking], 60, 3)
+    expect(result).toHaveLength(3)
+  })
+
+  it("id 없는 항목은 스킵", () => {
+    const malformed = [{ id: "a" }, { name: "no-id" } as unknown as Item, { id: "b" }]
+    const result = reciprocalRankFusion([malformed])
+    expect(result.map((r) => r.id)).toEqual(["a", "b"])
+  })
+})

--- a/web/tests/lib/work-agent/source-tracker.test.ts
+++ b/web/tests/lib/work-agent/source-tracker.test.ts
@@ -10,6 +10,7 @@ import {
   createSearchContext,
   extractDocumentId,
   extractDocumentIds,
+  extractRelatedDocumentIds,
   validateSources,
 } from "../../../src/lib/work-agent/source-tracker"
 import type { AnswerSource, SearchContext } from "../../../src/lib/work-agent/types"
@@ -101,6 +102,52 @@ describe("source-tracker", () => {
     it("null/undefined 입력에서 null 반환", () => {
       expect(extractDocumentId(null)).toBeNull()
       expect(extractDocumentId(undefined)).toBeNull()
+    })
+  })
+
+  // ============================================
+  // extractRelatedDocumentIds Tests
+  // ============================================
+  describe("extractRelatedDocumentIds", () => {
+    it("findRelated 결과에서 ID 목록 추출", () => {
+      const result = {
+        success: true,
+        data: {
+          documents: [
+            {
+              id: "rel-1",
+              title: "R1",
+              category: "X",
+              path: "X/r1.md",
+              relation: "outLink",
+              distance: 1,
+            },
+            {
+              id: "rel-2",
+              title: "R2",
+              category: "X",
+              path: "X/r2.md",
+              relation: "inLink",
+              distance: 1,
+            },
+          ],
+        },
+      }
+
+      expect(extractRelatedDocumentIds(result)).toEqual(["rel-1", "rel-2"])
+    })
+
+    it("실패 결과에서 빈 배열", () => {
+      expect(extractRelatedDocumentIds({ success: false })).toEqual([])
+      expect(extractRelatedDocumentIds(null)).toEqual([])
+    })
+
+    it("id 누락된 항목 필터링", () => {
+      const result = {
+        success: true,
+        data: { documents: [{ id: "rel-1" }, { title: "no-id" }, { id: "" }] },
+      }
+      expect(extractRelatedDocumentIds(result)).toEqual(["rel-1"])
     })
   })
 
@@ -238,6 +285,45 @@ describe("source-tracker", () => {
       const context = buildSearchContextFromSteps(steps)
       expect(context.obsidianDocIds.size).toBe(1)
       expect(context.obsidianDocIds.has("doc-1")).toBe(true)
+    })
+
+    it("findRelated 결과 ID도 context에 누적", () => {
+      const steps = [
+        {
+          toolResults: [
+            {
+              toolName: "findRelated",
+              result: {
+                success: true,
+                data: {
+                  documents: [
+                    {
+                      id: "rel-1",
+                      title: "관련 문서 1",
+                      category: "X",
+                      path: "X/r1.md",
+                      relation: "outLink",
+                      distance: 1,
+                    },
+                    {
+                      id: "rel-2",
+                      title: "관련 문서 2",
+                      category: "X",
+                      path: "X/r2.md",
+                      relation: "inLink",
+                      distance: 2,
+                    },
+                  ],
+                },
+              },
+            },
+          ],
+        },
+      ]
+
+      const context = buildSearchContextFromSteps(steps)
+      expect(context.obsidianDocIds.has("rel-1")).toBe(true)
+      expect(context.obsidianDocIds.has("rel-2")).toBe(true)
     })
 
     it("알 수 없는 도구 이름은 무시", () => {

--- a/web/tests/lib/work-agent/tools.test.ts
+++ b/web/tests/lib/work-agent/tools.test.ts
@@ -9,25 +9,39 @@ import { WorkAgentError } from "../../../src/lib/work-agent/types"
 // Obsidian 서버 모킹
 vi.mock("../../../src/lib/work-agent/obsidian.server", () => ({
   searchDocuments: vi.fn(),
+  hybridSearch: vi.fn(),
   readDocumentContent: vi.fn(),
+  findRelatedDocs: vi.fn(),
+}))
+
+// 쿼리 임베딩 모킹 (기본: throw → BM25 fallback 경로)
+vi.mock("../../../src/lib/work-agent/query-embedding", () => ({
+  embedQuery: vi.fn(),
 }))
 
 import {
+  findRelatedDocs,
+  hybridSearch,
   readDocumentContent,
   searchDocuments as searchDocumentsLocal,
 } from "../../../src/lib/work-agent/obsidian.server"
+import { embedQuery } from "../../../src/lib/work-agent/query-embedding"
 
 import {
   answer,
   answerSchema,
   createAnswerTool,
+  findRelated,
   readDocument,
   searchDocuments,
 } from "../../../src/lib/work-agent/tools"
 import type { SearchContext } from "../../../src/lib/work-agent/types"
 
 const mockSearchDocuments = searchDocumentsLocal as ReturnType<typeof vi.fn>
+const mockHybridSearch = hybridSearch as ReturnType<typeof vi.fn>
 const mockReadDocumentContent = readDocumentContent as ReturnType<typeof vi.fn>
+const mockFindRelatedDocs = findRelatedDocs as ReturnType<typeof vi.fn>
+const mockEmbedQuery = embedQuery as ReturnType<typeof vi.fn>
 
 const testContext = {
   toolCallId: "test-call",
@@ -38,6 +52,8 @@ const testContext = {
 describe("Work Agent Tools", () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    // 기본적으로 embedQuery는 실패 → BM25 fallback 경로로 동작
+    mockEmbedQuery.mockRejectedValue(new Error("embed disabled in tests"))
   })
 
   // ============================================
@@ -114,6 +130,55 @@ describe("Work Agent Tools", () => {
       expect(mockSearchDocuments).toHaveBeenCalledWith("test", 5)
     })
 
+    it("임베딩 성공 시 하이브리드 경로 사용", async () => {
+      mockEmbedQuery.mockResolvedValueOnce([0.1, 0.2, 0.3])
+      mockHybridSearch.mockReturnValue([
+        {
+          id: "doc-1",
+          title: "아키텍처",
+          category: "Design",
+          path: "Design/아키텍처.md",
+          summary: "요약",
+          tags: [],
+        },
+      ])
+
+      const result = (await searchDocuments.execute?.({ query: "설계 철학" }, testContext)) as {
+        success: true
+        data: { documents: Array<{ id: string }> }
+      }
+
+      expect(mockEmbedQuery).toHaveBeenCalledWith("설계 철학")
+      expect(mockHybridSearch).toHaveBeenCalledWith("설계 철학", [0.1, 0.2, 0.3], 20)
+      expect(mockSearchDocuments).not.toHaveBeenCalled()
+      expect(result.success).toBe(true)
+      expect(result.data.documents).toHaveLength(1)
+    })
+
+    it("임베딩 실패 시 BM25로 자동 fallback", async () => {
+      // 기본 mockEmbedQuery가 이미 reject 상태
+      mockSearchDocuments.mockReturnValue([
+        {
+          id: "doc-1",
+          title: "BM25 결과",
+          category: "Misc",
+          path: "Misc/x.md",
+          summary: "요약",
+          tags: [],
+        },
+      ])
+
+      const result = (await searchDocuments.execute?.({ query: "fallback" }, testContext)) as {
+        success: true
+        data: { documents: Array<{ id: string }> }
+      }
+
+      expect(mockSearchDocuments).toHaveBeenCalledWith("fallback", 20)
+      expect(mockHybridSearch).not.toHaveBeenCalled()
+      expect(result.success).toBe(true)
+      expect(result.data.documents).toHaveLength(1)
+    })
+
     it("에러: 볼트 읽기 실패", async () => {
       mockSearchDocuments.mockImplementation(() => {
         throw new WorkAgentError("Vault read error", "VAULT_ERROR")
@@ -170,7 +235,7 @@ describe("Work Agent Tools", () => {
   // readDocument Tests
   // ============================================
   describe("readDocument", () => {
-    it("성공: 문서 내용 반환", async () => {
+    it("성공: 문서 내용 + outLinks 반환", async () => {
       mockReadDocumentContent.mockReturnValue({
         id: "React.js--useRef",
         title: "useRef",
@@ -179,6 +244,8 @@ describe("Work Agent Tools", () => {
         summary: "useRef 훅에 대한 설명",
         tags: ["React.js"],
         content: "# useRef\n\nuseRef는 React 훅입니다.",
+        outLinks: [{ id: "React.js--useState", title: "useState" }],
+        inLinks: [],
       })
 
       const result = await readDocument.execute?.({ documentId: "React.js--useRef" }, testContext)
@@ -193,6 +260,7 @@ describe("Work Agent Tools", () => {
             path: "React.js/useRef.md",
           },
           content: "# useRef\n\nuseRef는 React 훅입니다.",
+          outLinks: [{ id: "React.js--useState", title: "useState" }],
         },
       })
     })
@@ -218,6 +286,60 @@ describe("Work Agent Tools", () => {
       })
 
       const result = await readDocument.execute?.({ documentId: "broken-doc" }, testContext)
+
+      expect(result).toEqual({
+        success: false,
+        error: {
+          code: "VAULT_ERROR",
+          message: "Obsidian 볼트 읽기 중 오류가 발생했습니다.",
+          retryable: false,
+        },
+      })
+    })
+  })
+
+  // ============================================
+  // findRelated Tool Tests
+  // ============================================
+  describe("findRelated", () => {
+    it("성공: 관련 문서 반환 (depth 기본값 1)", async () => {
+      mockFindRelatedDocs.mockReturnValue([
+        {
+          id: "doc-2",
+          title: "관련 문서",
+          category: "Design",
+          path: "Design/관련.md",
+          relation: "outLink",
+          distance: 1,
+        },
+      ])
+
+      const result = (await findRelated.execute?.({ documentId: "doc-1" }, testContext)) as {
+        success: true
+        data: { documents: Array<{ id: string; relation: string }>; totalFound: number }
+      }
+
+      expect(mockFindRelatedDocs).toHaveBeenCalledWith("doc-1", 1)
+      expect(result.success).toBe(true)
+      expect(result.data.documents).toHaveLength(1)
+      expect(result.data.documents[0].relation).toBe("outLink")
+      expect(result.data.totalFound).toBe(1)
+    })
+
+    it("성공: depth=2 전달", async () => {
+      mockFindRelatedDocs.mockReturnValue([])
+
+      await findRelated.execute?.({ documentId: "doc-1", depth: 2 }, testContext)
+
+      expect(mockFindRelatedDocs).toHaveBeenCalledWith("doc-1", 2)
+    })
+
+    it("에러: 볼트 읽기 실패", async () => {
+      mockFindRelatedDocs.mockImplementation(() => {
+        throw new WorkAgentError("graph error", "VAULT_ERROR")
+      })
+
+      const result = await findRelated.execute?.({ documentId: "doc-1" }, testContext)
 
       expect(result).toEqual({
         success: false,

--- a/web/tests/pages/api/chat.test.ts
+++ b/web/tests/pages/api/chat.test.ts
@@ -57,6 +57,7 @@ vi.mock("@/lib/work-agent", () => ({
   workAgentTools: {
     searchDocuments: { description: "search" },
     readDocument: { description: "read" },
+    findRelated: { description: "find-related" },
   },
 }))
 
@@ -114,13 +115,17 @@ describe("/api/chat", () => {
       lastToolName: null,
       lastQueries: [],
       totalSearchCount: 0,
+      findRelatedCount: 0,
+      hasCalledFindRelated: false,
     })
-    mockBuildDynamicSystemPrompt.mockImplementation((options?: { analysis?: { lastQueries?: string[] } }) => {
-      const queries = options?.analysis?.lastQueries ?? []
-      return queries.length > 0
-        ? `soft guidance\n이전 검색 쿼리\n${queries.map((q) => `"${q}"`).join("\n")}`
-        : "dynamic prompt"
-    })
+    mockBuildDynamicSystemPrompt.mockImplementation(
+      (options?: { analysis?: { lastQueries?: string[] } }) => {
+        const queries = options?.analysis?.lastQueries ?? []
+        return queries.length > 0
+          ? `soft guidance\n이전 검색 쿼리\n${queries.map((q) => `"${q}"`).join("\n")}`
+          : "dynamic prompt"
+      }
+    )
     mockCreateSearchContext.mockReturnValue({})
     mockCreateAnswerTool.mockReturnValue({ description: "answer" })
     mockResolveThinkingLevel.mockReturnValue("high")
@@ -208,7 +213,10 @@ describe("/api/chat", () => {
     })
 
     const streamTextArg = mockStreamText.mock.calls[0][0] as {
-      prepareStep: (args: { stepNumber: number; steps: Array<{ toolCalls?: Array<{ toolName: string }> }> }) => {
+      prepareStep: (args: {
+        stepNumber: number
+        steps: Array<{ toolCalls?: Array<{ toolName: string }> }>
+      }) => {
         system: string
         activeTools: string[]
         toolChoice: "required" | "auto"
@@ -218,42 +226,128 @@ describe("/api/chat", () => {
     const step1 = streamTextArg.prepareStep({ stepNumber: 1, steps: [] })
 
     expect(step0.toolChoice).toBe("required")
-    expect(step0.activeTools).toEqual(["searchDocuments", "readDocument"])
+    expect(step0.activeTools).toEqual(["searchDocuments", "readDocument", "findRelated"])
     expect(step1.toolChoice).toBe("auto")
-    expect(step1.activeTools).toEqual(["searchDocuments", "readDocument", "answer"])
+    expect(step1.activeTools).toEqual(["searchDocuments", "readDocument", "findRelated", "answer"])
   })
 
-  it("answer 미호출 상태에서 step2+는 answer required 가드가 동작한다", async () => {
+  it("contact_inquiry: answer 미호출 상태에서 step3+ answer 강제 가드가 동작한다", async () => {
+    mockClassifyIntent.mockReturnValueOnce({
+      intent: "contact_inquiry",
+      confidence: 0.9,
+      keywords: ["연락처"],
+    })
+
     await POST({
       request: new Request("http://localhost/api/chat?variant=frontend", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
-          messages: [{ role: "user", parts: [{ type: "text", text: "경력 알려줘" }] }],
+          messages: [{ role: "user", parts: [{ type: "text", text: "연락처 알려줘" }] }],
         }),
       }),
     })
 
     const streamTextArg = mockStreamText.mock.calls[0][0] as {
-      prepareStep: (args: { stepNumber: number; steps: Array<{ toolCalls?: Array<{ toolName: string }> }> }) => {
+      prepareStep: (args: {
+        stepNumber: number
+        steps: Array<{ toolCalls?: Array<{ toolName: string }> }>
+      }) => {
         activeTools: string[]
         toolChoice: "required" | "auto"
       }
     }
 
-    const step2WithoutAnswer = streamTextArg.prepareStep({
-      stepNumber: 2,
+    const step3WithoutAnswer = streamTextArg.prepareStep({
+      stepNumber: 3,
       steps: [{ toolCalls: [{ toolName: "searchDocuments" }] }],
     })
-    expect(step2WithoutAnswer.toolChoice).toBe("required")
-    expect(step2WithoutAnswer.activeTools).toEqual(["answer"])
+    expect(step3WithoutAnswer.toolChoice).toBe("required")
+    expect(step3WithoutAnswer.activeTools).toEqual(["answer"])
 
-    const step2WithAnswer = streamTextArg.prepareStep({
-      stepNumber: 2,
+    const step3WithAnswer = streamTextArg.prepareStep({
+      stepNumber: 3,
       steps: [{ toolCalls: [{ toolName: "answer" }] }],
     })
-    expect(step2WithAnswer.toolChoice).toBe("auto")
-    expect(step2WithAnswer.activeTools).toEqual(["searchDocuments", "readDocument", "answer"])
+    expect(step3WithAnswer.toolChoice).toBe("auto")
+    expect(step3WithAnswer.activeTools).toEqual([
+      "searchDocuments",
+      "readDocument",
+      "findRelated",
+      "answer",
+    ])
+  })
+
+  it("technical_inquiry: step 5까지는 연쇄 탐색 허용, step 6부터 answer 강제", async () => {
+    await POST({
+      request: new Request("http://localhost/api/chat?variant=frontend", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          messages: [{ role: "user", parts: [{ type: "text", text: "설계 철학 알려줘" }] }],
+        }),
+      }),
+    })
+
+    const streamTextArg = mockStreamText.mock.calls[0][0] as {
+      prepareStep: (args: {
+        stepNumber: number
+        steps: Array<{ toolCalls?: Array<{ toolName: string }> }>
+      }) => {
+        activeTools: string[]
+        toolChoice: "required" | "auto"
+      }
+    }
+
+    const step5 = streamTextArg.prepareStep({
+      stepNumber: 5,
+      steps: [{ toolCalls: [{ toolName: "searchDocuments" }] }],
+    })
+    expect(step5.toolChoice).toBe("auto")
+
+    const step6 = streamTextArg.prepareStep({
+      stepNumber: 6,
+      steps: [{ toolCalls: [{ toolName: "searchDocuments" }] }],
+    })
+    expect(step6.toolChoice).toBe("required")
+    expect(step6.activeTools).toEqual(["answer"])
+  })
+
+  it("동일 도구 5회 이상 연속이면 즉시 answer 강제", async () => {
+    mockAnalyzeToolCallPattern.mockReturnValueOnce({
+      consecutiveSameToolCount: 5,
+      lastToolName: "searchDocuments",
+      lastQueries: ["q1", "q2", "q3", "q4", "q5"],
+      totalSearchCount: 5,
+      findRelatedCount: 0,
+      hasCalledFindRelated: false,
+    })
+
+    await POST({
+      request: new Request("http://localhost/api/chat?variant=frontend", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          messages: [{ role: "user", parts: [{ type: "text", text: "뭐 했어?" }] }],
+        }),
+      }),
+    })
+
+    const streamTextArg = mockStreamText.mock.calls[0][0] as {
+      prepareStep: (args: {
+        stepNumber: number
+        steps: Array<{ toolCalls?: Array<{ toolName: string }> }>
+      }) => {
+        activeTools: string[]
+        toolChoice: "required" | "auto"
+      }
+    }
+    const step1 = streamTextArg.prepareStep({
+      stepNumber: 1,
+      steps: [{ toolCalls: [{ toolName: "searchDocuments" }] }],
+    })
+    expect(step1.toolChoice).toBe("required")
+    expect(step1.activeTools).toEqual(["answer"])
   })
 
   it("반복 호출 3회 이상이면 prepareStep.system에 soft guidance와 이전 쿼리가 포함된다", async () => {
@@ -275,7 +369,10 @@ describe("/api/chat", () => {
     })
 
     const streamTextArg = mockStreamText.mock.calls[0][0] as {
-      prepareStep: (args: { stepNumber: number; steps: Array<{ toolCalls?: Array<{ toolName: string }> }> }) => {
+      prepareStep: (args: {
+        stepNumber: number
+        steps: Array<{ toolCalls?: Array<{ toolName: string }> }>
+      }) => {
         system: string
       }
     }
@@ -286,9 +383,9 @@ describe("/api/chat", () => {
 
     expect(step1.system).toContain("soft guidance")
     expect(step1.system).toContain("이전 검색 쿼리")
-    expect(step1.system).toContain("\"query1\"")
-    expect(step1.system).toContain("\"query2\"")
-    expect(step1.system).toContain("\"query3\"")
+    expect(step1.system).toContain('"query1"')
+    expect(step1.system).toContain('"query2"')
+    expect(step1.system).toContain('"query3"')
   })
 
   it("contact_inquiry 에서는 thinkingLevel low를 사용한다", async () => {

--- a/web/tests/scripts/vault-wiki-link-utils.test.ts
+++ b/web/tests/scripts/vault-wiki-link-utils.test.ts
@@ -1,0 +1,142 @@
+import { beforeAll, describe, expect, it } from "vitest"
+
+type ParseWikiLinks = (content: string) => {
+  outLinks: Array<{ target: string; display?: string }>
+  imageLinks: Array<{ target: string; display?: string }>
+}
+
+interface DocIndex {
+  pathMap: Map<string, string>
+  titleMap: Map<string, string[]>
+  basenameMap: Map<string, string[]>
+}
+
+type BuildDocIndex = (
+  documents: Array<{ id: string; title: string; path: string; category?: string }>
+) => DocIndex
+
+type ResolveWikiTarget = (
+  rawTarget: string,
+  docIndex: DocIndex,
+  context?: {
+    sourceCategory?: string
+    catalog?: Map<string, { category?: string }>
+    onAmbiguous?: (target: string, candidates: string[]) => void
+  }
+) => string | null
+
+let parseWikiLinks: ParseWikiLinks
+let buildDocIndex: BuildDocIndex
+let resolveWikiTarget: ResolveWikiTarget
+
+beforeAll(async () => {
+  const modulePath = "../../../scripts/vault-wiki-link-utils.mjs"
+  const mod = (await import(modulePath)) as {
+    parseWikiLinks: ParseWikiLinks
+    buildDocIndex: BuildDocIndex
+    resolveWikiTarget: ResolveWikiTarget
+  }
+  parseWikiLinks = mod.parseWikiLinks
+  buildDocIndex = mod.buildDocIndex
+  resolveWikiTarget = mod.resolveWikiTarget
+})
+
+describe("parseWikiLinks", () => {
+  it("단순 [[링크]] 추출", () => {
+    const result = parseWikiLinks("이 문서는 [[TLS 협상]]을 참조합니다.")
+    expect(result.outLinks).toEqual([{ target: "TLS 협상", display: undefined }])
+    expect(result.imageLinks).toEqual([])
+  })
+
+  it("alias가 있는 [[link|display]] 추출", () => {
+    const result = parseWikiLinks("[[TLS 협상|협상 과정]]")
+    expect(result.outLinks).toEqual([{ target: "TLS 협상", display: "협상 과정" }])
+  })
+
+  it("앵커(#)와 블록(^) 제거", () => {
+    const result = parseWikiLinks("[[TLS 협상#암호스위트]] 그리고 [[문서^abc123]]")
+    expect(result.outLinks.map((l) => l.target)).toEqual(["TLS 협상", "문서"])
+  })
+
+  it("임베드 이미지는 imageLinks로 분리", () => {
+    const result = parseWikiLinks("![[Pasted image 20250211.png]] 본문 [[TLS 협상]]")
+    expect(result.outLinks.map((l) => l.target)).toEqual(["TLS 협상"])
+    expect(result.imageLinks.map((l) => l.target)).toEqual(["Pasted image 20250211.png"])
+  })
+
+  it("이미지가 아닌 임베드는 outLinks/imageLinks 둘 다에서 제외", () => {
+    const result = parseWikiLinks("![[일반 노트 이름]]")
+    expect(result.outLinks).toEqual([])
+    expect(result.imageLinks).toEqual([])
+  })
+
+  it("빈 문자열/null 안전 처리", () => {
+    expect(parseWikiLinks("")).toEqual({ outLinks: [], imageLinks: [] })
+    expect(parseWikiLinks(undefined as unknown as string)).toEqual({
+      outLinks: [],
+      imageLinks: [],
+    })
+  })
+})
+
+describe("resolveWikiTarget", () => {
+  const docs = [
+    { id: "Network--TLS", title: "TLS 협상", path: "Network/TLS 협상.md" },
+    { id: "Network--DNS", title: "DNS Lookup", path: "Network/DNS Lookup.md" },
+    {
+      id: "Frontend--TLS",
+      title: "TLS 협상",
+      path: "Frontend/TLS 협상.md",
+      category: "Frontend",
+    },
+  ]
+
+  it("title 정확 매치", () => {
+    const index = buildDocIndex(docs)
+    expect(resolveWikiTarget("DNS Lookup", index)).toBe("Network--DNS")
+  })
+
+  it("경로 포함 target은 path 매칭 우선", () => {
+    const index = buildDocIndex(docs)
+    expect(resolveWikiTarget("Network/TLS 협상", index)).toBe("Network--TLS")
+    expect(resolveWikiTarget("Frontend/TLS 협상", index)).toBe("Frontend--TLS")
+  })
+
+  it("대소문자 무시 매칭", () => {
+    const index = buildDocIndex(docs)
+    expect(resolveWikiTarget("dns lookup", index)).toBe("Network--DNS")
+  })
+
+  it("동명 충돌: 같은 카테고리 우선", () => {
+    const index = buildDocIndex(docs)
+    const catalog = new Map(docs.map((d) => [d.id, { category: d.category ?? "" }]))
+    catalog.set("Network--TLS", { category: "Network" })
+
+    const result = resolveWikiTarget("TLS 협상", index, {
+      sourceCategory: "Frontend",
+      catalog,
+    })
+    expect(result).toBe("Frontend--TLS")
+  })
+
+  it("동명 충돌: 카테고리 힌트 없으면 onAmbiguous 호출 후 첫 매치", () => {
+    const index = buildDocIndex(docs)
+    const ambiguous: string[] = []
+    const result = resolveWikiTarget("TLS 협상", index, {
+      onAmbiguous: (target) => ambiguous.push(target),
+    })
+    expect(ambiguous).toContain("TLS 협상")
+    expect(result).not.toBeNull()
+  })
+
+  it("매치 실패 → null", () => {
+    const index = buildDocIndex(docs)
+    expect(resolveWikiTarget("존재하지 않는 문서", index)).toBeNull()
+  })
+
+  it("빈 target → null", () => {
+    const index = buildDocIndex(docs)
+    expect(resolveWikiTarget("", index)).toBeNull()
+    expect(resolveWikiTarget("   ", index)).toBeNull()
+  })
+})


### PR DESCRIPTION
## Summary

- BM25(MiniSearch) + Vertex AI `text-embedding-005` 하이브리드 검색을 **RRF**로 결합해 "이 개발자의 아키텍처 설계 철학" 같은 추상적 질문에도 대응
- 빌드 타임에 `[[wiki link]]`를 파싱해 **outLinks/inLinks 그래프**를 구축, content-hash 캐시로 재빌드 가속
- `readDocument` 응답에 outLinks 포함 + 새 **`findRelated` 툴**로 연쇄 탐색 지원
- 채팅 UI `source-carousel` Dialog를 **전체 마크다운 뷰**로 확장, `[[wiki]]` 클릭 시 Dialog 내 네비게이션
- 의도별 answer 강제 step 분기(technical/career=6, 그 외=3) + 5회 연속 호출 가드 + `stepCountIs` 20으로 상향
- 임베딩 API 실패 시 BM25 자동 fallback, 배포 중단 방지

## Architecture

```
Build time:  vault → parseWikiLinks → resolveWikiTarget → inLinks 역인덱스 →
             text-embedding-005 배치 호출 (해시 캐시) → vault-data.json + vault-embeddings.json

Run time:    user query → embedQuery(LRU) → hybridSearch = RRF(BM25, vector) →
             readDocument(outLinks 포함) → findRelated(depth 1|2) → answer
```

## Test plan

- [x] `pnpm test:run` — 258 tests passed (신규 테스트 5파일: rrf / link-graph / wiki-link-parser / wiki-link-preprocessor / findRelated tool)
- [x] `pnpm lint` 통과, `pnpm typecheck` 에러 0건
- [x] `pnpm build:vault` — 395 문서 · 147 out-links · 120 inLinks · 임베딩 env 없으면 자동 스킵
- [ ] Dev 서버에서 "이 개발자의 아키텍처 설계 철학을 알려주세요" → 로그에 findRelated 호출, source-carousel 렌더링
- [ ] source 카드 클릭 → Dialog 전체 마크다운 표시, `[[링크]]` 클릭 시 해당 문서 로드, 뒤로가기 동작

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Wiki link navigation: Jump between related documents via wiki-style links throughout the app.
  * Semantic search: Enhanced search combining keyword matching with AI-powered semantic understanding for better results.
  * Related documents discovery: Find contextually connected documents based on link relationships.
  * Full document previews: View complete document content with in-modal wiki link navigation and back navigation.

* **Improvements**
  * Hybrid search combining traditional keyword search with semantic relevance ranking.
  * Document embeddings precomputed for faster semantic searches.

* **Tests**
  * Added comprehensive test coverage for wiki link processing, semantic search, related document discovery, and link graph traversal.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->